### PR TITLE
feat!: base hook on search not own state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-
 ![Scaleway-Logo-Vertical-Purple-RGB](https://user-images.githubusercontent.com/14060273/111292512-89a52180-8648-11eb-909e-3bd109b1b97c.png)
 
 ![Codecov](https://img.shields.io/codecov/c/github/scaleway/scaleway-lib)
 ![GitHub closed issues](https://img.shields.io/github/issues-closed/scaleway/scaleway-lib)
 ![dependencies](https://david-dm.org/scaleway/scaleway-lib.svg)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/scaleway/scaleway-lib)
-
 
 # scaleway-lib
 
@@ -32,6 +30,7 @@ scaleway-lib is a set of NPM packages used at Scaleway.
 ---
 
 ## Available packages
+
 ## Available packages
 
 - [`@scaleway/countries`](./packages/countries/README.md): ISO 3166/3166-2 coutries JSON database.
@@ -53,11 +52,11 @@ scaleway-lib is a set of NPM packages used at Scaleway.
   ![npm](https://img.shields.io/npm/v/@scaleway/random-name)
 
 - [`@scaleway/use-query-params`](./packages/use-query-params/README.md):
- A tiny react hook to read and update URLs query parameters.
+  A tiny react hook to read and update URLs query parameters.
 
   ![npm](https://img.shields.io/npm/dm/@scaleway/use-query-params)
   ![npm bundle size](https://img.shields.io/bundlephobia/min/@scaleway/use-query-params)
-  ![npm](https://img.shields.io/npm/v/@scaleway/regex)
+  ![npm](https://img.shields.io/npm/v/@scaleway/use-query-params)
 
 - [`@scaleway/regex`](./packages/regex/README.md): usefull regex named.
 

--- a/packages/use-query-params/README.md
+++ b/packages/use-query-params/README.md
@@ -30,29 +30,52 @@ const Component = () => {
 }
 ```
 
-## Usage with a custom updater
+### Set query params
+
+Merge current query params with the new ones passed in parameters.
 
 ```js
+//In this exemple we admit that we have an URL that include : `?compagny=Scaleway".
 import React from 'react'
 import useQueryParams from '@scaleway/use-query-params'
 
 // this component should be wrap with a Router
 const Component = () => {
-  const updater = (prevState, nextState) => ({
-    ...prevState,
-    ...Object.keys(nextState).reduce(
-      (acc, key) => ({ ...acc, [key]: nextState[key].toUpperCase() }),
-      {},
-    ),
-  })
-  const { queryParams, setQueryParams } = useQueryParams({ updater })
-  const { user } = queryParams
-  const setUser = () => setQueryParams({ user: 'John' })
-  // ?user=JOHN
+  const { queryParams, setQueryParams } = useQueryParams()
+  const { user, compagny } = queryParams // user will be undefined and compagny will be "Scaleway"
+  const setUser = () => setQueryParams({ user: 'John' }) // user will be "John" and compagny will be "Scaleway"
+  // ?compagny=Scaleway&user=John
 
   return (
     <>
       <h1>User: {user}</h1>
+      <h1>Compagny: {compagny}</h1>
+      <button onClick={setUser}>Set User John</button>
+    </>
+  )
+}
+```
+
+### Replace query params
+
+Erase current query params and replace by the new ones passed in parameters.
+
+```js
+//In this exemple we admit that we have an URL that include : `?compagny=Scaleway".
+import React from 'react'
+import useQueryParams from '@scaleway/use-query-params'
+
+// this component should be wrap with a Router
+const Component = () => {
+  const { queryParams, setQueryParams } = useQueryParams()
+  const { user, compagny } = queryParams // user will be undefined and compagny will be "Scaleway"
+  const setUser = () => replaceQueryParams({ user: 'John' }) // user will be "John" and compagny will be undefined
+  // ?user=John
+
+  return (
+    <>
+      <h1>User: {user}</h1>
+      <h1>Compagny: {compagny}</h1>
       <button onClick={setUser}>Set User John</button>
     </>
   )

--- a/packages/use-query-params/src/__tests__/index.js
+++ b/packages/use-query-params/src/__tests__/index.js
@@ -250,4 +250,49 @@ describe('useQueryParam', () => {
     })
     expect(result.current.queryParams).toEqual({})
   })
+
+  test('should work correctly when have multiple useQueryParams', () => {
+    const { result } = renderHook(
+      () => ({
+        qp1: useQueryParams(),
+        qp2: useQueryParams(),
+      }),
+      {
+        wrapper: wrapper({ search: '' }),
+      },
+    )
+
+    act(() => {
+      result.current.qp1.setQueryParams({ name: 'John' })
+    })
+    expect(result.current.qp2.queryParams).toEqual({
+      name: 'John',
+    })
+    expect(result.current.qp1.queryParams).toEqual({
+      name: 'John',
+    })
+
+    act(() => {
+      result.current.qp2.replaceQueryParams({})
+    })
+
+    expect(result.current.qp1.queryParams).toEqual({})
+    expect(result.current.qp2.queryParams).toEqual({})
+
+    act(() => {
+      result.current.qp1.setQueryParams({ user: 'John' })
+    })
+    act(() => {
+      result.current.qp2.setQueryParams({ compagny: 'Scaleway' })
+    })
+
+    expect(result.current.qp1.queryParams).toEqual({
+      user: 'John',
+      compagny: 'Scaleway',
+    })
+    expect(result.current.qp2.queryParams).toEqual({
+      user: 'John',
+      compagny: 'Scaleway',
+    })
+  })
 })

--- a/packages/use-query-params/src/__tests__/index.js
+++ b/packages/use-query-params/src/__tests__/index.js
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react-hooks'
 import React from 'react'
-import { MemoryRouter, useHistory } from 'react-router-dom'
-import useQueryParam from '..'
+import { MemoryRouter } from 'react-router-dom'
+import useQueryParams from '..'
 
 // eslint-disable-next-line react/prop-types
 const wrapper = ({ pathname = 'one', search }) => ({ children }) => (
@@ -12,18 +12,19 @@ const wrapper = ({ pathname = 'one', search }) => ({ children }) => (
 
 describe('useQueryParam', () => {
   it('should set one object', () => {
-    const { result } = renderHook(() => useQueryParam(), {
+    const { result } = renderHook(() => useQueryParams(), {
       wrapper: wrapper({ search: 'user=john' }),
     })
 
     act(() => {
       result.current.setQueryParams({ user: 'John' })
     })
+
     expect(result.current.queryParams).toEqual({ user: 'John' })
   })
 
   it('should correctly set with different value', () => {
-    const { result } = renderHook(() => useQueryParam(), {
+    const { result } = renderHook(() => useQueryParams(), {
       wrapper: wrapper({ search: 'user=john' }),
     })
 
@@ -47,7 +48,7 @@ describe('useQueryParam', () => {
   })
 
   it('should set one complexe object', () => {
-    const { result } = renderHook(() => useQueryParam(), {
+    const { result } = renderHook(() => useQueryParams(), {
       wrapper: wrapper({ search: 'user=john' }),
     })
 
@@ -70,7 +71,7 @@ describe('useQueryParam', () => {
   })
 
   it('should get queryParams from existing location', () => {
-    const { result } = renderHook(() => useQueryParam(), {
+    const { result } = renderHook(() => useQueryParams(), {
       wrapper: wrapper({ search: 'user=john' }),
     })
 
@@ -78,7 +79,7 @@ describe('useQueryParam', () => {
   })
 
   it('should should handle array, boolean, number and string from existing location', () => {
-    const { result } = renderHook(() => useQueryParam(), {
+    const { result } = renderHook(() => useQueryParams(), {
       wrapper: wrapper({
         search: 'string=john&boolean=true&number=123&array=handle,array,format',
       }),
@@ -93,7 +94,7 @@ describe('useQueryParam', () => {
   })
 
   it('should get queryParams from existing location and set new params', () => {
-    const { result } = renderHook(() => useQueryParam(), {
+    const { result } = renderHook(() => useQueryParams(), {
       wrapper: wrapper({ search: 'user=john' }),
     })
 
@@ -116,7 +117,7 @@ describe('useQueryParam', () => {
   })
 
   it('should correctly set different objects before rerender', () => {
-    const { result, rerender } = renderHook(() => useQueryParam(), {
+    const { result, rerender } = renderHook(() => useQueryParams(), {
       wrapper: wrapper({ search: '' }),
     })
 
@@ -149,18 +150,19 @@ describe('useQueryParam', () => {
     })
   })
 
-  test('should render good params with parallel changes', async () => {
-    jest.useFakeTimers()
-    const { result } = renderHook(() => useQueryParam(), {
+  it('should render good params with parallel changes', async () => {
+    const { result } = renderHook(() => useQueryParams(), {
       wrapper: wrapper({ search: '' }),
     })
     act(() => {
       result.current.setQueryParams({ name: 'John' })
+    })
+    act(() => {
       result.current.setQueryParams({ lastName: 'Doe' })
+    })
+    act(() => {
       result.current.setQueryParams({ compagny: 'Scaleway' })
     })
-
-    jest.runAllTimers()
 
     expect(result.current.queryParams).toEqual({
       name: 'John',
@@ -171,8 +173,6 @@ describe('useQueryParam', () => {
     act(() => {
       result.current.setQueryParams({ name: 'John' })
     })
-
-    jest.runAllTimers()
 
     expect(result.current.queryParams).toEqual({
       name: 'John',
@@ -182,7 +182,7 @@ describe('useQueryParam', () => {
   })
 
   test('should erase params', () => {
-    const { result } = renderHook(() => useQueryParam(), {
+    const { result } = renderHook(() => useQueryParams(), {
       wrapper: wrapper({ search: '' }),
     })
 
@@ -200,7 +200,7 @@ describe('useQueryParam', () => {
       lastName: 'Doe',
     })
     act(() => {
-      result.current.replaceQueryparams({ compagny: 'Scaleway' })
+      result.current.replaceQueryParams({ compagny: 'Scaleway' })
     })
     expect(result.current.queryParams).toEqual({
       compagny: 'Scaleway',
@@ -208,30 +208,23 @@ describe('useQueryParam', () => {
   })
 
   test('should correctly set query params with array', () => {
-    jest.useFakeTimers()
-    const { result, rerender } = renderHook(
-      () => [useQueryParam(), useHistory()],
-      {
-        wrapper: wrapper({ search: '' }),
-      },
-    )
+    const { result, rerender } = renderHook(() => useQueryParams(), {
+      wrapper: wrapper({ search: '' }),
+    })
 
     act(() => {
-      result.current[0].setQueryParams({
+      result.current.setQueryParams({
         names: ['John', null, 'Jane', null, undefined, ''],
       })
     })
-    jest.runAllTimers()
-    expect(result.current[0].queryParams).toEqual({
-      names: ['John', null, 'Jane', null, undefined, ''],
+    expect(result.current.queryParams).toEqual({
+      names: ['John', 'Jane'],
     })
-    expect(result.current[1].location.search).toEqual('?names=John,Jane')
-
     rerender()
   })
 
   test('should correctly with existing array', () => {
-    const { result } = renderHook(() => useQueryParam(), {
+    const { result } = renderHook(() => useQueryParams(), {
       wrapper: wrapper({ search: 'names=John,,Jane,,,' }),
     })
 
@@ -241,23 +234,20 @@ describe('useQueryParam', () => {
   })
 
   test('should work correctly when search is empty', () => {
-    jest.useFakeTimers()
-    const { result } = renderHook(() => useQueryParam(), {
+    const { result } = renderHook(() => useQueryParams(), {
       wrapper: wrapper({ search: '' }),
     })
 
     act(() => {
       result.current.setQueryParams({ name: 'John' })
     })
-    jest.runAllTimers()
     expect(result.current.queryParams).toEqual({
       name: 'John',
     })
 
     act(() => {
-      result.current.replaceQueryparams({})
+      result.current.replaceQueryParams({})
     })
-    jest.runAllTimers()
     expect(result.current.queryParams).toEqual({})
   })
 })


### PR DESCRIPTION
Why did not just use Router Context ?
- It cant be tested properly 😅 

By adding a context on top of this hook we make possible to useQueryParams everywhere