### PR TITLE
fix(use-dataloader): avoid exception when options are not defined

### DIFF
--- a/packages/use-dataloader/src/__tests__/useDataLoader.test.js
+++ b/packages/use-dataloader/src/__tests__/useDataLoader.test.js
@@ -20,6 +20,23 @@ const wrapper = ({ children }) => (
 )
 
 describe('useDataLoader', () => {
+  test('should render correctly without options', async () => {
+    const { result, waitForNextUpdate, rerender } = renderHook(
+      props => useDataLoader(props.key, props.method),
+      {
+        wrapper,
+        initialProps,
+      },
+    )
+    expect(result.current.data).toBe(undefined)
+    expect(result.current.isLoading).toBe(true)
+    rerender()
+    await waitForNextUpdate()
+    expect(result.current.data).toBe(true)
+    expect(result.current.isSuccess).toBe(true)
+    expect(result.current.isLoading).toBe(false)
+  })
+
   test('should render correctly with enabled true', async () => {
     const { result, waitForNextUpdate, rerender } = renderHook(
       props => useDataLoader(props.key, props.method, props.config),

--- a/packages/use-dataloader/src/useDataLoader.js
+++ b/packages/use-dataloader/src/useDataLoader.js
@@ -22,7 +22,7 @@ const useDataLoader = (
     enabled = true,
     reloadOnKeyChange = true,
     keepPreviousData = true,
-  },
+  } = {},
 ) => {
   const {
     addCachedData,


### PR DESCRIPTION
A tiny bug I found when trying to use the hook 