### PR TITLE
fix(use-dataloader): move cacheKeyPrefix logic into hook to trigger reload

### DIFF
--- a/packages/use-dataloader/src/DataLoaderProvider.js
+++ b/packages/use-dataloader/src/DataLoaderProvider.js
@@ -34,11 +34,11 @@ const DataLoaderProvider = ({ children, cacheKeyPrefix }) => {
       if (key && typeof key === 'string' && newData) {
         setCachedData(actualCachedData => ({
           ...actualCachedData,
-          [`${cacheKeyPrefix ? `${cacheKeyPrefix}-` : ''}${key}`]: newData,
+          [key]: newData,
         }))
       }
     },
-    [setCachedData, cacheKeyPrefix],
+    [setCachedData],
   )
 
   const addReload = useCallback(
@@ -76,13 +76,13 @@ const DataLoaderProvider = ({ children, cacheKeyPrefix }) => {
       if (key && typeof key === 'string') {
         setCachedData(actualCachedData => {
           const tmp = actualCachedData
-          delete tmp[`${cacheKeyPrefix ? `${cacheKeyPrefix}-` : ''}${key}`]
+          delete tmp[key]
 
           return tmp
         })
       }
     },
-    [setCachedData, cacheKeyPrefix],
+    [setCachedData],
   )
   const clearAllCachedData = useCallback(() => {
     setCachedData({})
@@ -100,20 +100,13 @@ const DataLoaderProvider = ({ children, cacheKeyPrefix }) => {
     )
   }, [])
 
-  const getCachedData = useCallback(
-    key => {
-      if (key) {
-        return (
-          cachedData.current[
-            `${cacheKeyPrefix ? `${cacheKeyPrefix}-` : ''}${key}`
-          ] || undefined
-        )
-      }
+  const getCachedData = useCallback(key => {
+    if (key) {
+      return cachedData.current[key] || undefined
+    }
 
-      return cachedData.current
-    },
-    [cacheKeyPrefix],
-  )
+    return cachedData.current
+  }, [])
 
   const getReloads = useCallback(key => {
     if (key) {
@@ -127,6 +120,7 @@ const DataLoaderProvider = ({ children, cacheKeyPrefix }) => {
     () => ({
       addCachedData,
       addReload,
+      cacheKeyPrefix,
       clearAllCachedData,
       clearAllReloads,
       clearCachedData,
@@ -138,14 +132,15 @@ const DataLoaderProvider = ({ children, cacheKeyPrefix }) => {
     }),
     [
       addCachedData,
-      clearReload,
-      clearCachedData,
-      getCachedData,
-      getReloads,
       addReload,
-      reload,
+      cacheKeyPrefix,
       clearAllCachedData,
       clearAllReloads,
+      clearCachedData,
+      clearReload,
+      getCachedData,
+      getReloads,
+      reload,
       reloadAll,
     ],
   )

--- a/packages/use-dataloader/src/__tests__/DataLoaderProvider.test.js
+++ b/packages/use-dataloader/src/__tests__/DataLoaderProvider.test.js
@@ -7,10 +7,6 @@ const wrapper = ({ children }) => (
   <DataLoaderProvider>{children}</DataLoaderProvider>
 )
 
-const wrapperWithCacheKey = ({ children }) => (
-  <DataLoaderProvider cacheKeyPrefix="sample">{children}</DataLoaderProvider>
-)
-
 describe('DataLoaderProvider', () => {
   test('should render correctly', async () => {
     render(<DataLoaderProvider>Test</DataLoaderProvider>)
@@ -29,51 +25,8 @@ describe('DataLoaderProvider', () => {
     expect(result.current.getCachedData().test).toBe('test')
   })
 
-  test('should add cached data with cacheKeyPrefix', async () => {
-    const { result } = renderHook(useDataLoaderContext, {
-      wrapper: wrapperWithCacheKey,
-    })
-    expect(result.current.getCachedData()).toStrictEqual({})
-
-    act(() => {
-      result.current.addCachedData('test', 'test')
-      result.current.addCachedData(3, 'testWrong')
-    })
-
-    expect(Object.values(result.current.getCachedData()).length).toBe(1)
-    expect(result.current.getCachedData()['sample-test']).toBe('test')
-  })
-
   test('should delete cached data', async () => {
     const { result } = renderHook(useDataLoaderContext, { wrapper })
-
-    act(() => {
-      result.current.addCachedData('testA', 'testA')
-      result.current.addCachedData('testB', 'testB')
-      result.current.addCachedData('testC', 'testC')
-      result.current.addCachedData('testD', 'testD')
-      result.current.addCachedData('testE', 'testE')
-    })
-    expect(result.current.getCachedData('testA')).toBe('testA')
-
-    act(() => {
-      result.current.clearCachedData()
-      result.current.clearCachedData('testA')
-    })
-    expect(Object.values(result.current.getCachedData()).length).toBe(4)
-    expect(result.current.getCachedData().testA).toBe(undefined)
-
-    act(() => {
-      result.current.clearAllCachedData()
-    })
-    expect(Object.values(result.current.getCachedData()).length).toBe(0)
-    expect(result.current.getCachedData()).toStrictEqual({})
-  })
-
-  test('should delete cached data with cacheKeyPrefix', async () => {
-    const { result } = renderHook(useDataLoaderContext, {
-      wrapper: wrapperWithCacheKey,
-    })
 
     act(() => {
       result.current.addCachedData('testA', 'testA')

--- a/packages/use-dataloader/src/useDataLoader.js
+++ b/packages/use-dataloader/src/useDataLoader.js
@@ -40,7 +40,7 @@ const Actions = {
  * @returns {useDataLoaderResult} hook result containing data, request state, and method to reload the data
  */
 const useDataLoader = (
-  key,
+  fetchKey,
   method,
   {
     enabled = true,
@@ -51,8 +51,13 @@ const useDataLoader = (
     pollingInterval,
   } = {},
 ) => {
-  const { addReload, clearReload, getCachedData, addCachedData } =
-    useDataLoaderContext()
+  const {
+    addReload,
+    clearReload,
+    getCachedData,
+    addCachedData,
+    cacheKeyPrefix,
+  } = useDataLoaderContext()
   const [{ status, error }, dispatch] = useReducer(reducer, {
     error: undefined,
     status: StatusEnum.IDLE,
@@ -60,6 +65,12 @@ const useDataLoader = (
 
   const addReloadRef = useRef(addReload)
   const clearReloadRef = useRef(clearReload)
+
+  const key = useMemo(
+    () => `${cacheKeyPrefix ? `${cacheKeyPrefix}-` : ''}${fetchKey}`,
+    [cacheKeyPrefix, fetchKey],
+  )
+
   const previousDataRef = useRef()
   const isMountedRef = useRef(enabled)
   const methodRef = useRef(method)

--- a/packages/use-dataloader/src/useDataLoader.js
+++ b/packages/use-dataloader/src/useDataLoader.js
@@ -66,10 +66,13 @@ const useDataLoader = (
   const addReloadRef = useRef(addReload)
   const clearReloadRef = useRef(clearReload)
 
-  const key = useMemo(
-    () => `${cacheKeyPrefix ? `${cacheKeyPrefix}-` : ''}${fetchKey}`,
-    [cacheKeyPrefix, fetchKey],
-  )
+  const key = useMemo(() => {
+    if (!fetchKey || typeof fetchKey !== 'string') {
+      return fetchKey
+    }
+
+    return `${cacheKeyPrefix ? `${cacheKeyPrefix}-` : ''}${fetchKey}`
+  }, [cacheKeyPrefix, fetchKey])
 
   const previousDataRef = useRef()
   const isMountedRef = useRef(enabled)


### PR DESCRIPTION
I forgot that to retrigger a reload the hook need to have a different key, thus we can't abstract it in the Provider