### PR TITLE
feat: refresh data on max lifetime reached

### DIFF
--- a/packages/use-dataloader/README.md
+++ b/packages/use-dataloader/README.md
@@ -77,10 +77,10 @@ const failingPromise = async () => {
 }
 
 const App = () => {
-  useDataLoader('local-error',  failingPromise,  {
-    onError: (error) => {
+  useDataLoader('local-error', failingPromise, {
+    onError: error => {
       console.log(`local onError: ${error}`)
-    }
+    },
   })
 
   useDataLoader('error', failingPromise)
@@ -88,7 +88,7 @@ const App = () => {
   return null
 }
 
-const globalOnError = (error) => {
+const globalOnError = error => {
   console.log(`global onError: ${error}`)
 }
 
@@ -219,6 +219,7 @@ const useDataLoader = (
     pollingInterval, // Relaunch the request after the last success
     enabled = true, // Launch request automatically
     keepPreviousData = true, // Do we need to keep the previous data after reload
+    maxDataLifetime, // Max time before previous success data is outdated (in millisecond)
   } = {},
 )
 ```

--- a/packages/use-dataloader/src/DataLoaderProvider.tsx
+++ b/packages/use-dataloader/src/DataLoaderProvider.tsx
@@ -24,6 +24,10 @@ type UseDataLoaderInitializerArgs<T = unknown> = {
   method: () => PromiseType<T>
   pollingInterval?: number
   keepPreviousData?: boolean
+  /**
+   * Max time before data from previous success is considered as outdated (in millisecond)
+   */
+  maxDataLifetime?: number
 }
 
 interface Context {
@@ -133,7 +137,7 @@ const DataLoaderProvider = ({
           [computeKey(key)]: newRequest,
         }))
 
-        addReload(key, newRequest.launch)
+        addReload(key, () => newRequest.load(true))
 
         return newRequest
       }

--- a/packages/use-dataloader/src/types.ts
+++ b/packages/use-dataloader/src/types.ts
@@ -24,6 +24,10 @@ export interface UseDataLoaderConfig<T = unknown> {
   onError?: OnErrorFn
   onSuccess?: OnSuccessFn
   pollingInterval?: number
+  /**
+   * Max time before data from previous success is considered as outdated (in millisecond)
+   */
+  maxDataLifetime?: number
 }
 
 /**

--- a/packages/use-dataloader/src/useDataLoader.ts
+++ b/packages/use-dataloader/src/useDataLoader.ts
@@ -19,6 +19,7 @@ const useDataLoader = <T>(
     onError,
     onSuccess,
     pollingInterval,
+    maxDataLifetime,
   }: UseDataLoaderConfig<T> = {},
 ): UseDataLoaderResult<T> => {
   const {
@@ -38,16 +39,24 @@ const useDataLoader = <T>(
       getRequest(fetchKey) ??
       addRequest(fetchKey, {
         key: fetchKey,
+        maxDataLifetime,
         method,
         pollingInterval,
       }),
-    [addRequest, fetchKey, getRequest, method, pollingInterval],
+    [
+      addRequest,
+      fetchKey,
+      getRequest,
+      method,
+      pollingInterval,
+      maxDataLifetime,
+    ],
   )
 
   useEffect(() => {
     if (enabled && request.status === StatusEnum.IDLE) {
       // eslint-disable-next-line no-void
-      void request.launch()
+      void request.load()
     }
   }, [request, enabled])
 
@@ -128,7 +137,7 @@ const useDataLoader = <T>(
     isPolling,
     isSuccess,
     previousData: previousDataRef.current,
-    reload: request.launch,
+    reload: () => request.load(true),
   }
 }
 


### PR DESCRIPTION
Consider data as outdated when maxLifetime is reached. Allow stalled data detection when there are multiple useDataLoader with same key. (Performance)