### PR TITLE
feat(use-i18n): allow default date-fns locale instead of lazy loading

### DIFF
--- a/packages/use-i18n/src/__tests__/usei18n.tsx
+++ b/packages/use-i18n/src/__tests__/usei18n.tsx
@@ -186,7 +186,7 @@ describe('i18n hook', () => {
     jest.spyOn(window, 'navigator', 'get').mockImplementation(() => ({
       language: 'en-US',
       languages: ['en-US', 'en'],
-    }))
+    }) as unknown as Navigator)
     const { result, waitForNextUpdate } = renderHook(() => useI18n(), {
       wrapper: wrapper({
         defaultLocale: 'fr',
@@ -201,7 +201,7 @@ describe('i18n hook', () => {
     jest.spyOn(window, 'navigator', 'get').mockImplementation(() => ({
       language: 'en',
       languages: undefined,
-    }))
+    }) as unknown as Navigator)
     const { result, waitForNextUpdate } = renderHook(() => useI18n(), {
       wrapper: wrapper({
         defaultLocale: 'fr',
@@ -278,7 +278,7 @@ describe('i18n hook', () => {
       }),
     })
     await waitForNextUpdate()
-    const identiqueTranslate = result.current.namespaceTranslation()
+    const identiqueTranslate = result.current.namespaceTranslation('')
     expect(identiqueTranslate('title')).toEqual(result.current.t('title'))
 
     const translate = result.current.namespaceTranslation('tests.test')

--- a/packages/use-i18n/src/index.ts
+++ b/packages/use-i18n/src/index.ts
@@ -1,5 +1,5 @@
-import usei18n from './usei18n'
+import I18nContextProvider from './usei18n'
 
 export * from './usei18n'
 
-export default usei18n
+export default I18nContextProvider

--- a/packages/use-i18n/src/usei18n.tsx
+++ b/packages/use-i18n/src/usei18n.tsx
@@ -120,16 +120,18 @@ const I18nContextProvider = ({
   children,
   defaultLoad,
   loadDateLocale,
+  defaultDateLocale,
   defaultLocale,
-  defaultTranslations,
-  enableDefaultLocale,
-  enableDebugKey,
-  localeItemStorage,
+  defaultTranslations = {},
+  enableDefaultLocale = false,
+  enableDebugKey = false,
+  localeItemStorage = LOCALE_ITEM_STORAGE,
   supportedLocales,
 }: {
   children: ReactNode,
   defaultLoad: LoadTranslationsFn,
-  loadDateLocale: LoadLocaleFn,
+  loadDateLocale?: LoadLocaleFn,
+  defaultDateLocale?: Locale,
   defaultLocale: string,
   defaultTranslations: TranslationsByLocales,
   enableDefaultLocale: boolean,
@@ -142,10 +144,10 @@ const I18nContextProvider = ({
   )
   const [translations, setTranslations] = useState<TranslationsByLocales>(defaultTranslations)
   const [namespaces, setNamespaces] = useState<string[]>([])
-  const [dateFnsLocale, setDateFnsLocale] = useState<Locale>()
+  const [dateFnsLocale, setDateFnsLocale] = useState<Locale>(defaultDateLocale ?? {})
 
   useEffect(() => {
-    loadDateLocale(currentLocale === 'en' ? 'en-GB' : currentLocale)
+    loadDateLocale?.(currentLocale === 'en' ? 'en-GB' : currentLocale)
       .then(setDateFnsLocale)
       .catch(() => loadDateLocale('en-GB').then(setDateFnsLocale))
   }, [loadDateLocale, currentLocale])
@@ -340,13 +342,6 @@ const I18nContextProvider = ({
   return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>
 }
 
-I18nContextProvider.defaultProps = {
-  defaultTranslations: {},
-  enableDebugKey: false,
-  enableDefaultLocale: false,
-  localeItemStorage: LOCALE_ITEM_STORAGE,
-}
-
 I18nContextProvider.propTypes = {
   children: PropTypes.node.isRequired,
   defaultLoad: PropTypes.func.isRequired,
@@ -354,7 +349,8 @@ I18nContextProvider.propTypes = {
   defaultTranslations: PropTypes.shape({}),
   enableDebugKey: PropTypes.bool,
   enableDefaultLocale: PropTypes.bool,
-  loadDateLocale: PropTypes.func.isRequired,
+  loadDateLocale: PropTypes.func,
+  defaultDateLocale: PropTypes.shape({}),
   localeItemStorage: PropTypes.string,
   supportedLocales: PropTypes.arrayOf(PropTypes.string).isRequired,
 }

--- a/packages/use-i18n/src/usei18n.tsx
+++ b/packages/use-i18n/src/usei18n.tsx
@@ -344,13 +344,13 @@ const I18nContextProvider = ({
 
 I18nContextProvider.propTypes = {
   children: PropTypes.node.isRequired,
+  defaultDateLocale: PropTypes.shape({}),
   defaultLoad: PropTypes.func.isRequired,
   defaultLocale: PropTypes.string.isRequired,
   defaultTranslations: PropTypes.shape({}),
   enableDebugKey: PropTypes.bool,
   enableDefaultLocale: PropTypes.bool,
   loadDateLocale: PropTypes.func,
-  defaultDateLocale: PropTypes.shape({}),
   localeItemStorage: PropTypes.string,
   supportedLocales: PropTypes.arrayOf(PropTypes.string).isRequired,
 }

--- a/packages/use-i18n/src/usei18n.tsx
+++ b/packages/use-i18n/src/usei18n.tsx
@@ -144,7 +144,7 @@ const I18nContextProvider = ({
   )
   const [translations, setTranslations] = useState<TranslationsByLocales>(defaultTranslations)
   const [namespaces, setNamespaces] = useState<string[]>([])
-  const [dateFnsLocale, setDateFnsLocale] = useState<Locale>(defaultDateLocale ?? {})
+  const [dateFnsLocale, setDateFnsLocale] = useState<Locale | undefined>(defaultDateLocale ?? undefined)
 
   useEffect(() => {
     loadDateLocale?.(currentLocale === 'en' ? 'en-GB' : currentLocale)


### PR DESCRIPTION
This is mainly intended when use-i18n is used server side, be it on unit tests or ssr.

On first render the provider will load date-fns locale and then rerender, trigger multiple errors on jest because we don't `act` on render.

When specified a default date-fns locale and no load function provider will not rerender