### PR TITLE
refactor: drop isFirstLoad to use isLoading only

### DIFF
--- a/packages/use-dataloader/README.md
+++ b/packages/use-dataloader/README.md
@@ -123,9 +123,14 @@ function MyComponent() {
     fakePromise,
   )
 
-  // Will be true during the promise
-  if (isLoading) {
+  // This is the first time we load the data
+  if (isLoading && !data) {
     return <div>Loading...</div>
+  }
+
+  // This happen when you already load the data but want to reload it
+  if (isLoading && data) {
+    return <div>Reloading...</div>
   }
 
   // Will be true when the promise is resolved
@@ -233,7 +238,7 @@ const useDataLoader = (
 |   Property   |                                                      Description                                                      |
 | :----------: | :-------------------------------------------------------------------------------------------------------------------: |
 |    isIdle    |                                         `true` if the request is not launched                                         |
-|  isLoading   |                                           `true` if the request is launched                                           |
+|  isLoading   |                    `true` if the request is launched **or** enabled is `true` and isIdle is `true`                    |
 |  isSuccess   |                                      `true`if the request finished successfully                                       |
 |   isError    |                                         `true` if the request throw an error                                          |
 |  isPolling   | `true` if the request if `enabled` is true, `pollingInterval` is defined and the status is `isLoading` or `isSuccess` |
@@ -241,5 +246,3 @@ const useDataLoader = (
 |     data     |     return the `initialData` if no data is fetched or not present in the cache otherwise return the data fetched      |
 |    error     |                                      return the error occured during the request                                      |
 |    reload    |                            allow you to reload the data (it doesn't clear the actual data)                            |
-
-

--- a/packages/use-dataloader/src/types.ts
+++ b/packages/use-dataloader/src/types.ts
@@ -53,7 +53,6 @@ export interface UseDataLoaderResult<T = unknown> {
   isLoading: boolean
   isPolling: boolean
   isSuccess: boolean
-  isFirstLoad: boolean
   previousData?: T
   reload: () => Promise<void>
 }

--- a/packages/use-dataloader/src/useDataLoader.ts
+++ b/packages/use-dataloader/src/useDataLoader.ts
@@ -85,8 +85,10 @@ const useDataLoader = <T>(
   const cancelMethodRef = useRef<(() => void) | undefined>(request?.cancel)
 
   const isLoading = useMemo(
-    () => request.status === StatusEnum.LOADING,
-    [request.status],
+    () =>
+      (enabled && request.status === StatusEnum.IDLE) ||
+      request.status === StatusEnum.LOADING,
+    [request.status, enabled],
   )
   const isIdle = useMemo(
     () => request.status === StatusEnum.IDLE,
@@ -103,11 +105,6 @@ const useDataLoader = <T>(
   const isPolling = useMemo(
     () => !!(enabled && pollingInterval && (isSuccess || isLoading)),
     [isSuccess, isLoading, enabled, pollingInterval],
-  )
-
-  const isFirstLoad = useMemo(
-    () => (enabled && isIdle) || isLoading,
-    [isLoading, isIdle, enabled],
   )
 
   useEffect(() => {
@@ -160,7 +157,6 @@ const useDataLoader = <T>(
     data: request.getData() || (initialData as T),
     error: request?.error,
     isError,
-    isFirstLoad,
     isIdle,
     isLoading,
     isPolling,


### PR DESCRIPTION
Drop isFirstLoad which check if request is enabled and idle to handle the case when you mount the hook and despite of enabled but request still idle. This will be dropped when we will batch updates.
Put this condition in isLoading