### PR TITLE
fix(types): add react18 types

### DIFF
--- a/packages/jest-helpers/src/helpers/renderWithTheme.tsx
+++ b/packages/jest-helpers/src/helpers/renderWithTheme.tsx
@@ -16,7 +16,7 @@ export type RenderWithThemeFn<Theme> = (
 ) => ReturnType<typeof render>
 
 export default function makeRenderWithTheme<Theme>(
-  Wrapper: FC<{ theme?: Theme }>,
+  Wrapper: FC<{ theme?: Theme; children: ReactNode }>,
 ): RenderWithThemeFn<Theme> {
   return (component, options, theme) =>
     render(

--- a/packages/jest-helpers/src/index.ts
+++ b/packages/jest-helpers/src/index.ts
@@ -1,5 +1,5 @@
 import { CreateSerializerOptions, createSerializer } from '@emotion/jest'
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 import makeRenderWithTheme, {
   RenderWithThemeFn,
 } from './helpers/renderWithTheme'
@@ -19,7 +19,7 @@ type Helpers<Theme> = {
 }
 
 export default function makeHelpers<Theme>(
-  Wrapper: FC<{ theme?: Theme }>,
+  Wrapper: FC<{ theme?: Theme; children: ReactNode }>,
   createSerializerOptions?: CreateSerializerOptions,
 ): Helpers<Theme> {
   expect.addSnapshotSerializer(createSerializer(createSerializerOptions))


### PR DESCRIPTION

children is omit from React.FC in React 18 types