### PR TITLE
feat(i18n): always required Locale generic

### DIFF
--- a/packages/use-i18n/src/__tests__/usei18n.tsx
+++ b/packages/use-i18n/src/__tests__/usei18n.tsx
@@ -320,24 +320,21 @@ describe('i18n hook', () => {
   })
 
   it('should use namespaceTranslation', async () => {
-    const { result } = renderHook(() => useI18n(), {
+    const { result } = renderHook(() => useI18n<Locale>(), {
       wrapper: wrapper({
         defaultLocale: 'en',
         defaultTranslations: { en },
       }),
     })
     await waitFor(() => {
-      const identiqueTranslate = result.current.namespaceTranslation('')
-      expect(identiqueTranslate('title')).toEqual(result.current.t('title'))
+      const identiqueTranslate = result.current.namespaceTranslation('tests')
+      expect(identiqueTranslate('test.namespaces')).toEqual(
+        result.current.t('tests.test.namespaces'),
+      )
     })
 
     const translate = result.current.namespaceTranslation('tests.test')
     expect(translate('namespaces')).toEqual('test')
-
-    // inception
-    const translate1 = result.current.namespaceTranslation('tests')
-    const translate2 = result.current.namespaceTranslation('test', translate1)
-    expect(translate2('namespaces')).toEqual(translate1('test.namespaces'))
   })
 
   it('should use formatNumber', async () => {

--- a/packages/use-i18n/src/__tests__/usei18n.tsx
+++ b/packages/use-i18n/src/__tests__/usei18n.tsx
@@ -8,6 +8,15 @@ import fr from './locales/fr.json'
 
 const LOCALE_ITEM_STORAGE = 'locales'
 
+type Locale = {
+  test: 'Test'
+  'with.identifier': 'Are you sure you want to delete {identifier}?'
+  plurals: '{numPhotos, plural, =0 {You have one photo.} other {You have # photos.}}'
+  subtitle: 'Here is a subtitle'
+  'tests.test.namespaces': 'test'
+  title: 'Welcome on @scaelway/ui i18n hook'
+}
+
 const wrapper =
   ({
     loadDateLocale = async (locale: string) =>
@@ -285,7 +294,7 @@ describe('i18n hook', () => {
   })
 
   it('should translate correctly with enableDebugKey', async () => {
-    const { result } = renderHook(() => useI18n(), {
+    const { result } = renderHook(() => useI18n<Locale>(), {
       wrapper: wrapper({
         defaultLocale: 'en',
         defaultTranslations: { en },

--- a/packages/use-i18n/src/types.ts
+++ b/packages/use-i18n/src/types.ts
@@ -8,38 +8,27 @@ import type {
 } from 'international-types'
 import type { ReactNode } from 'react'
 
-export type ReactParamsObject<
-  Value extends LocaleValue,
-  ReactParams extends boolean = true,
-> = Record<
+export type ReactParamsObject<Value extends LocaleValue> = Record<
   Params<Value>[number],
-  ReactParams extends true ? LocaleValue | ReactNode : LocaleValue
+  LocaleValue | ReactNode
 >
 
-export type TranslateFn<
-  Locale extends BaseLocale,
-  ReactParams extends boolean = true,
-> = <
+export type TranslateFn<Locale extends BaseLocale> = <
   Key extends LocaleKeys<Locale, undefined>,
   Value extends LocaleValue = ScopedValue<Locale, undefined, Key>,
 >(
   key: Key,
-  ...params: Params<Value>['length'] extends 0
-    ? []
-    : [ReactParamsObject<Value, ReactParams>]
+  ...params: Params<Value>['length'] extends 0 ? [] : [ReactParamsObject<Value>]
 ) => string
 
-export type ScopedTranslateFn<
-  Locale extends BaseLocale,
-  ReactParams extends boolean = true,
-> = <Scope extends Scopes<Locale>>(
+export type ScopedTranslateFn<Locale extends BaseLocale> = <
+  Scope extends Scopes<Locale>,
+>(
   scope: Scope,
 ) => <
   Key extends LocaleKeys<Locale, Scope>,
   Value extends LocaleValue = ScopedValue<Locale, Scope, Key>,
 >(
   key: Key,
-  ...params: Params<Value>['length'] extends 0
-    ? []
-    : [ReactParamsObject<Value, ReactParams>]
+  ...params: Params<Value>['length'] extends 0 ? [] : [ReactParamsObject<Value>]
 ) => string

--- a/packages/use-i18n/src/types.ts
+++ b/packages/use-i18n/src/types.ts
@@ -8,27 +8,38 @@ import type {
 } from 'international-types'
 import type { ReactNode } from 'react'
 
-export type ReactParamsObject<Value extends LocaleValue> = Record<
+export type ReactParamsObject<
+  Value extends LocaleValue,
+  ReactParams extends boolean = true,
+> = Record<
   Params<Value>[number],
-  LocaleValue | ReactNode
+  ReactParams extends true ? LocaleValue | ReactNode : LocaleValue
 >
 
-export type TranslateFn<Locale extends BaseLocale> = <
+export type TranslateFn<
+  Locale extends BaseLocale,
+  ReactParams extends boolean = true,
+> = <
   Key extends LocaleKeys<Locale, undefined>,
   Value extends LocaleValue = ScopedValue<Locale, undefined, Key>,
 >(
   key: Key,
-  ...params: Params<Value>['length'] extends 0 ? [] : [ReactParamsObject<Value>]
+  ...params: Params<Value>['length'] extends 0
+    ? []
+    : [ReactParamsObject<Value, ReactParams>]
 ) => string
 
-export type ScopedTranslateFn<Locale extends BaseLocale> = <
-  Scope extends Scopes<Locale>,
->(
+export type ScopedTranslateFn<
+  Locale extends BaseLocale,
+  ReactParams extends boolean = true,
+> = <Scope extends Scopes<Locale>>(
   scope: Scope,
 ) => <
   Key extends LocaleKeys<Locale, Scope>,
   Value extends LocaleValue = ScopedValue<Locale, Scope, Key>,
 >(
   key: Key,
-  ...params: Params<Value>['length'] extends 0 ? [] : [ReactParamsObject<Value>]
+  ...params: Params<Value>['length'] extends 0
+    ? []
+    : [ReactParamsObject<Value, ReactParams>]
 ) => string

--- a/packages/use-i18n/src/usei18n.tsx
+++ b/packages/use-i18n/src/usei18n.tsx
@@ -20,7 +20,7 @@ import ReactDOM from 'react-dom'
 import dateFormat, { FormatDateOptions } from './formatDate'
 import unitFormat, { FormatUnitOptions } from './formatUnit'
 import formatters, { IntlListFormatOptions } from './formatters'
-import type { ScopedTranslateFn, TranslateFn } from './types'
+import type { ReactParamsObject, ScopedTranslateFn, TranslateFn } from './types'
 
 const LOCALE_ITEM_STORAGE = 'locale'
 
@@ -73,7 +73,7 @@ interface Context<Locale extends BaseLocale> {
   ) => Promise<string>
   locales: string[]
   namespaces: string[]
-  namespaceTranslation: ScopedTranslateFn<Locale, false>
+  namespaceTranslation: ScopedTranslateFn<Locale>
   relativeTime: (
     date: Date | number,
     options?: {
@@ -91,7 +91,7 @@ interface Context<Locale extends BaseLocale> {
   ) => string
   setTranslations: React.Dispatch<React.SetStateAction<TranslationsByLocales>>
   switchLocale: (locale: string) => void
-  t: TranslateFn<Locale, false>
+  t: TranslateFn<Locale>
   translations: TranslationsByLocales
 }
 
@@ -310,8 +310,8 @@ const I18nContextProvider = ({
     [dateFnsLocale],
   )
 
-  const translate = useCallback<TranslateFn<any, false>>(
-    (key, ...context) => {
+  const translate = useCallback(
+    (key: string, context?: ReactParamsObject<any>) => {
       const value = translations[currentLocale]?.[key] as string
       if (!value) {
         if (enableDebugKey) {
@@ -323,7 +323,7 @@ const I18nContextProvider = ({
       if (context) {
         return formatters
           .getTranslationFormat(value, currentLocale)
-          .format(...context) as string
+          .format(context) as string
       }
 
       return value
@@ -331,11 +331,9 @@ const I18nContextProvider = ({
     [currentLocale, translations, enableDebugKey],
   )
 
-  const namespaceTranslation = useCallback<ScopedTranslateFn<any, false>>(
-    namespace =>
-      (identifier, ...context) =>
-        translate(`${namespace}.${identifier}`, ...context) ||
-        translate(identifier, ...context),
+  const namespaceTranslation = useCallback(
+    (scope: string) => (key: string, context?: ReactParamsObject<any>) =>
+      translate(`${scope}.${key}`, context) || translate(key, context),
     [translate],
   )
 


### PR DESCRIPTION
`useI18n()` / `namespaceTranslation()` now always require a generic to be passed to force type-safety.