### PR TITLE
feat(use-i18n): required generic

### DIFF
--- a/packages/use-i18n/src/__tests__/usei18n.tsx
+++ b/packages/use-i18n/src/__tests__/usei18n.tsx
@@ -17,6 +17,12 @@ type Locale = {
   title: 'Welcome on @scaelway/ui i18n hook'
 }
 
+type NamespaceLocale = {
+  name: 'Name'
+  lastName: 'Last Name'
+  languages: 'Languages'
+}
+
 const wrapper =
   ({
     loadDateLocale = async (locale: string) =>
@@ -92,7 +98,7 @@ describe('i18n hook', () => {
   })
 
   it('should use defaultLoad, useTranslation, switch local and translate', async () => {
-    const { result } = renderHook(() => useTranslation([]), {
+    const { result } = renderHook(() => useTranslation<Locale>([]), {
       wrapper: wrapper({ defaultLocale: 'en' }),
     })
     // first render there is no load
@@ -130,7 +136,7 @@ describe('i18n hook', () => {
     }) => import(`./locales/namespaces/${locale}/${namespace}.json`)
 
     const { result } = renderHook(
-      () => useTranslation(['user', 'profile'], load),
+      () => useTranslation<NamespaceLocale>(['user', 'profile'], load),
       {
         wrapper: wrapper({
           defaultLocale: 'en',
@@ -185,13 +191,16 @@ describe('i18n hook', () => {
       namespace: string
     }) => import(`./locales/namespaces/${locale}/${namespace}.json`)
 
-    const { result } = renderHook(() => useTranslation(['user'], load), {
-      wrapper: wrapper({
-        defaultLocale: 'fr',
-        enableDefaultLocale: true,
-        supportedLocales: ['en', 'fr'],
-      }),
-    })
+    const { result } = renderHook(
+      () => useTranslation<NamespaceLocale>(['user'], load),
+      {
+        wrapper: wrapper({
+          defaultLocale: 'fr',
+          enableDefaultLocale: true,
+          supportedLocales: ['en', 'fr'],
+        }),
+      },
+    )
 
     // current local will be 'en' based on navigator
     // await load of locales

--- a/packages/use-i18n/src/__typetests__/namespaceTranslation.test.ts
+++ b/packages/use-i18n/src/__typetests__/namespaceTranslation.test.ts
@@ -1,7 +1,7 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import { expectError, expectType } from 'tsd-lite'
 import { useI18n } from '../usei18n'
 
-// eslint-disable-next-line react-hooks/rules-of-hooks
 const { namespaceTranslation } = useI18n<{
   hello: 'world'
   'doe.john': 'John Doe'
@@ -50,3 +50,7 @@ expectType<string>(
 )
 expectError(scopedT3('john', {}))
 expectError(scopedT3('john'))
+
+// Required generic
+const { namespaceTranslation: namespaceTranslation2 } = useI18n()
+expectError(namespaceTranslation2('test'))

--- a/packages/use-i18n/src/__typetests__/t.test.tsx
+++ b/packages/use-i18n/src/__typetests__/t.test.tsx
@@ -1,7 +1,7 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import { expectError, expectType } from 'tsd-lite'
-import { useI18n } from '../usei18n'
+import { useI18n, useTranslation } from '../usei18n'
 
-// eslint-disable-next-line react-hooks/rules-of-hooks
 const { t } = useI18n<{
   hello: 'world'
   'doe.john': 'John Doe'
@@ -58,3 +58,7 @@ expectType<string>(
     ),
   }),
 )
+
+// Required generic
+const { t: t2 } = useI18n()
+expectError(t2('test'))

--- a/packages/use-i18n/src/usei18n.tsx
+++ b/packages/use-i18n/src/usei18n.tsx
@@ -27,7 +27,7 @@ const LOCALE_ITEM_STORAGE = 'locale'
 type TranslationsByLocales = Record<string, BaseLocale>
 type RequiredGenericContext<Locale extends BaseLocale> =
   keyof Locale extends never
-    ? Context<Locale> & {
+    ? Omit<Context<Locale>, 't' | 'namespaceTranslation'> & {
         t: (str: 'You must pass a generic argument to useI18n()') => void
         namespaceTranslation: (
           str: 'You must pass a generic argument to useI18n()',


### PR DESCRIPTION
When using `useI18n()` / `useTranslation()` without providing a generic for the locale, `t` and `namespaceTranslation` will throw an error (`You must pass a generic argument to ****`) to enforce the usage of a Locale.