### PR TITLE
feat(regex): add alphanumdashunderscoredotsparenthesis regex

### DIFF
--- a/packages/regex/src/__tests__/index.ts
+++ b/packages/regex/src/__tests__/index.ts
@@ -15,6 +15,7 @@ import {
   alphanumdashdotsspaces,
   alphanumdashorempty,
   alphanumdashspaces,
+  alphanumdashunderscoredotsspacesparenthesis,
   alphanumdots,
   ascii,
   backupKey,
@@ -40,6 +41,7 @@ import {
 } from '..'
 
 const alphanumdashdotsText = 'testwithdashdots-.'
+const alphanumdashunderscoredotsparenthesisText = 'testwithdashdots-_. ()'
 const alphanumdashText = 'testwithdash-'
 const asciiLetters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 const asciiLowercase = 'abcdefghijklmnopqrstuvwxyz'
@@ -251,6 +253,30 @@ describe('@regex', () => {
       [macAddress1, false],
     ])('should match regex %s to be %s', (string, expected) => {
       expect(alphanumdashdotsspaces.test(string)).toBe(expected)
+    })
+  })
+
+  describe('alphanumdashunderscoredotsspacesparenthesis', () => {
+    test.each([
+      [alphanumdashText, true],
+      [alphanumdashdotsText, true],
+      [alphanumdashunderscoredotsparenthesisText, true],
+      [asciiLetters, true],
+      [asciiLowercase, true],
+      [asciiUppercase, true],
+      [digitsTest, true],
+      [emailTest, false],
+      [octdigits, true],
+      [hexdigits, true],
+      [printable, false],
+      [punctuation, false],
+      [whitespace, true],
+      [cronTest, false],
+      [macAddress1, false],
+    ])('should match regex %s to be %s', (string, expected) => {
+      expect(alphanumdashunderscoredotsspacesparenthesis.test(string)).toBe(
+        expected,
+      )
     })
   })
 

--- a/packages/regex/src/index.ts
+++ b/packages/regex/src/index.ts
@@ -6,6 +6,9 @@ export const alphanumdash = /^[a-zA-Z0-9-]*$/
 export const alphanumdashdots = /^[a-zA-Z0-9-.]*$/
 export const alphanumdashdotsorempty = /^$|^[a-zA-Z0-9-.]*$/
 export const alphanumdashdotsspaces = /^[a-zA-Z0-9-.\s]*$/
+export const alphanumdashunderscoredotsspacesparenthesis =
+  /^[a-zA-Z0-9-_.()\s]*$/
+
 export const alphanumdashorempty = /^$|^[a-zA-Z0-9-]*$/
 export const alphanumdashspaces = /^[a-zA-Z0-9-\s]*$/
 export const alphanumdots = /^[a-zA-Z0-9.]*$/


### PR DESCRIPTION
For iam resources names, I need to be able to validate this regex.