### PR TITLE
fix(renovate): remove matchManagers & matchPackageNames

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -46,8 +46,6 @@
     },
     {
       "matchDepTypes": ["engines"],
-      "matchPackageNames": ["node"],
-      "matchManagers": ["pnpm"],
       "rangeStrategy": "widen"
     }
   ]


### PR DESCRIPTION
Fix https://github.com/scaleway/scaleway-lib/issues/563