### PR TITLE
feat(regex): advanced domain regex for non ASCII characters

### DIFF
--- a/packages/regex/src/__tests__/index.ts
+++ b/packages/regex/src/__tests__/index.ts
@@ -1,5 +1,6 @@
 import {
   absoluteLinuxPath,
+  advancedDomainName,
   alpha,
   alphaDashes,
   alphaLower,
@@ -46,6 +47,8 @@ const alphanumdashdotsText = 'testwithdashdots-.'
 const alphanumdashunderscoredotsparenthesisText = 'testwithdashdots-_. ()'
 const alphanumdashText = 'testwithdash-'
 const asciiLetters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+const nonAsciiLetters =
+  'ÀÁÂÃÄÅàáâãäåÇçÈÉÊËèéêëÌÍÎÏìíîïÑñÒÓÔÕÖòóôõöÙÚÛÜùúûüÝýÿĀāĈĉĜĝĤĥĴĵŜŝŴŵŶŷāăąǎćĉčċđēĕėęǝğōŏőǒśŝşšūŭůűǔüźżž'
 const asciiLowercase = 'abcdefghijklmnopqrstuvwxyz'
 const asciiUppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 const backupKeyTest = '123456789ABCEDFGHIJIKLMNOPQRSTUV'
@@ -538,6 +541,30 @@ describe('@regex', () => {
       ...(urls.map(urlString => [urlString, false]) as [string, boolean][]),
     ])('should match regex %s to be %s', (string, expected) => {
       expect(uppercaseBasicDomain.test(string)).toBe(expected)
+    })
+  })
+  describe('advancedDomain', () => {
+    test.each([
+      [asciiLetters, false],
+      [nonAsciiLetters, false],
+      [asciiLowercase, false],
+      [asciiUppercase, false],
+      [backupKeyTest, false],
+      [domain, true],
+      [subDomain, true],
+      [longTldDomain, true],
+      [digitsTest, false],
+      [emailTest, false],
+      [octdigits, false],
+      [hexdigits, false],
+      [printable, false],
+      [punctuation, false],
+      [whitespace, false],
+      [cronTest, false],
+      [macAddress1, false],
+      ...(urls.map(urlString => [urlString, false]) as [string, boolean][]),
+    ])('should match regex %s to be %s', (string, expected) => {
+      expect(advancedDomainName.test(string)).toBe(expected)
     })
   })
 

--- a/packages/regex/src/index.ts
+++ b/packages/regex/src/index.ts
@@ -25,6 +25,9 @@ export const backupKey = /^[A-Z0-9]{32}$/
 export const basicDomain = /^[a-z0-9-]+(\.[a-z0-9-]{1,63})+$/
 export const uppercaseBasicDomain =
   /^(?![-])+[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]{1,63})+$/
+// It will include special character that are non ASCII but valid for internationalized domain names (IDN)
+export const advancedDomainName =
+  /^(?:(?:(?:[a-zA-Z0-9À-ÖØ-öø-ÿ](?:[a-zA-Z0-9À-ÖØ-öø-ÿ-]{0,61}[a-zA-Z0-9À-ÖØ-öø-ÿ])?)\.)+[a-zA-Z]{2,}|(?:[0-9]{1,3}\.){3}[0-9]{1,3})(?::[\d]{1,5})?$/
 
 export const cron = /^((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*) ?){5,7})$/
 export const digits = /^[0-9]*$/


### PR DESCRIPTION
Regex for domain with non ASCII characters but valid for internationalized domain names (IDN).

![Screenshot 2023-01-12 at 11 21 27](https://user-images.githubusercontent.com/15812968/212041490-c8a0133d-49a6-4ca2-90ce-f76d7d4732a9.png)
