### PR TITLE
fix: changesets renovate checkout current branch

### DIFF
--- a/.github/workflows/changesets-renovate.yml
+++ b/.github/workflows/changesets-renovate.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+          ref: ${{ github.head_ref }}
       - name: Git Identity
         run: |
           git config --global user.name 'Scaleway Bot'


### PR DESCRIPTION
Checkout the current branch when running changesets-renovate on renovate PRs.