### PR TITLE
fix(changesets-renovate): current branch check

### DIFF
--- a/.changeset/nine-seals-push.md
+++ b/.changeset/nine-seals-push.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/changesets-renovate': patch
+---
+
+Fix current branch check

--- a/packages/changesets-renovate/src/index.ts
+++ b/packages/changesets-renovate/src/index.ts
@@ -54,7 +54,7 @@ async function getBumps(files: string[]): Promise<Map<string, string>> {
 }
 
 export async function run() {
-  const branch = await simpleGit().branch(['--show-current'])
+  const branch = await simpleGit().branch()
 
   console.log('Detected branch:', branch)
 


### PR DESCRIPTION
Remove `--show-current` flag from `git branch` since simple-git already returns the current branch.