### PR TITLE
feat(changesets-renovate): ignore changes in workspace root `package.json`

### DIFF
--- a/.changeset/happy-items-look.md
+++ b/.changeset/happy-items-look.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/changesets-renovate': minor
+---
+
+Ignore changes in workspace's root package.json


### PR DESCRIPTION
Ignore workspace's root `package.json` changes, because it doesn't impact any package.