### PR TITLE
feat(changesets-renovate): create a new commit instead of amend + fore push

### DIFF
--- a/.changeset/funny-files-roll.md
+++ b/.changeset/funny-files-roll.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/changesets-renovate': patch
+---
+
+Create a new commit instead of amend + force push

--- a/packages/changesets-renovate/src/__tests__/generate-changeset.ts
+++ b/packages/changesets-renovate/src/__tests__/generate-changeset.ts
@@ -110,13 +110,8 @@ describe('generate changeset file', () => {
     expect(fs.readFile).toHaveBeenCalledWith(file, 'utf8')
     expect(fs.writeFile).toMatchSnapshot()
     expect(add).toHaveBeenCalledWith(fileName)
-    expect(commit).toHaveBeenCalledWith([], undefined, {
-      '-C': null,
-      HEAD: null,
-      '--amend': null,
-      '--no-edit': null,
-    })
-    expect(push).toHaveBeenCalledWith(['--force'])
+    expect(commit).toHaveBeenCalledWith(`Add changeset renovate-${rev}`)
+    expect(push).toHaveBeenCalledTimes(1)
   })
 
   it('should ignore workspace package.json', async () => {

--- a/packages/changesets-renovate/src/index.ts
+++ b/packages/changesets-renovate/src/index.ts
@@ -98,19 +98,14 @@ export async function run() {
     return
   }
 
-  const shortHash = await simpleGit().revparse(['--short', 'HEAD'])
-  const fileName = `.changeset/renovate-${shortHash.trim()}.md`
+  const shortHash = (await simpleGit().revparse(['--short', 'HEAD'])).trim()
+  const fileName = `.changeset/renovate-${shortHash}.md`
   const packageBumps = await getBumps(files)
 
   await createChangeset(fileName, packageBumps, packageNames)
   await simpleGit().add(fileName)
-  await simpleGit().commit([], undefined, {
-    '-C': null,
-    HEAD: null,
-    '--amend': null,
-    '--no-edit': null,
-  })
-  await simpleGit().push(['--force'])
+  await simpleGit().commit(`Add changeset renovate-${shortHash}`)
+  await simpleGit().push()
 }
 
 run().catch(console.error)


### PR DESCRIPTION
Amending a force-pushing causes an infinite loop with renovate: force-pushing causes renovate to run again and force-push, causing the GitHub action to re-run and force-pushing...