### PR TITLE
chore: remove typescript changesets

### DIFF
--- a/.changeset/renovate-792c857.md
+++ b/.changeset/renovate-792c857.md
@@ -1,5 +1,0 @@
----
-'@scaleway/eslint-config-react': patch
----
-
-Updated dependency `typescript` to `5.0.2`.


### PR DESCRIPTION
Not needed as it only bumps internal/devDeps 