### PR TITLE
ci: add npm package provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: actions/checkout@v3.5.2
       - name: Git Identity
@@ -36,3 +37,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+


### PR DESCRIPTION
Add npm package provenance, similar to what we did on https://github.com/scaleway/scaleway-ui/pull/2471

https://github.blog/2023-04-19-introducing-npm-package-provenance/