### PR TITLE
feat(use-i18n): make the provider compatible with server side rendering

### DIFF
--- a/.changeset/shiny-hairs-decide.md
+++ b/.changeset/shiny-hairs-decide.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/use-i18n': minor
+---
+
+feat(use-i18n): make the provider compatible with server side rendering

--- a/packages/use-i18n/src/usei18n.tsx
+++ b/packages/use-i18n/src/usei18n.tsx
@@ -50,17 +50,21 @@ const getCurrentLocale = ({
   supportedLocales: string[]
   localeItemStorage: string
 }): string => {
-  const { languages } = navigator
-  const browserLocales = [...new Set(languages.map(getLocaleFallback))]
-  const localeStorage = localStorage.getItem(localeItemStorage)
+  if (typeof window !== 'undefined') {
+    const { languages } = navigator
+    const browserLocales = [...new Set(languages.map(getLocaleFallback))]
+    const localeStorage = localStorage.getItem(localeItemStorage)
 
-  return (
-    localeStorage ||
-    browserLocales.find(
-      locale => locale && supportedLocales.includes(locale),
-    ) ||
-    defaultLocale
-  )
+    return (
+      localeStorage ||
+      browserLocales.find(
+        locale => locale && supportedLocales.includes(locale),
+      ) ||
+      defaultLocale
+    )
+  }
+
+  return defaultLocale
 }
 
 type Context<Locale extends BaseLocale> = {


### PR DESCRIPTION
Verify that the provider renders client side before checking locale from either `navigator` or `localSotrage`.