### PR TITLE
fix: use-random-name version in lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,7 +290,7 @@ importers:
   packages/use-random-name:
     dependencies:
       '@scaleway/random-name':
-        specifier: ^4.0.1
+        specifier: ^4.0.2
         version: link:../random-name
       react:
         specifier: '>=16.8 || 18'


### PR DESCRIPTION
Fixes:

![Screenshot 2023-07-12 at 15 31 45](https://github.com/scaleway/scaleway-lib/assets/43268759/a2ba54ec-4340-4022-ac2e-b9cf7f6cfe1e)
