### PR TITLE
fix(formatUnit): allow to change base on formatUnit

### DIFF
--- a/.changeset/young-shirts-unite.md
+++ b/.changeset/young-shirts-unite.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/use-i18n': minor
+---
+
+Allow to change base on formatUnit calculations

--- a/packages/use-i18n/src/__tests__/__snapshots__/formatUnit.ts.snap
+++ b/packages/use-i18n/src/__tests__/__snapshots__/formatUnit.ts.snap
@@ -116,6 +116,120 @@ exports[`formatUnit should work with { unit: 'zettabyte' } 1`] = `"12,56 Zo"`;
 
 exports[`formatUnit should work with { unit: 'zettabyte-humanized' } 1`] = `"0 Zo"`;
 
+exports[`formatUnit should work with base { base: 2, unit: 'bit' } 1`] = `"4,294,967,296 b"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'bit-humanized' } 1`] = `"4,294,967,296 b"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'bit-per-second' } 1`] = `"4,294,967,296 bps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'bit-per-second-humanized' } 1`] = `"4,294,967,296 bps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'bits-humanized' } 1`] = `"4 Gb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'bits-per-second-humanized' } 1`] = `"4 Gbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'byte' } 1`] = `"4,294,967,296 B"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'byte-humanized' } 1`] = `"4,294,967,296 B"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'bytes-humanized' } 1`] = `"4 GB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'exabit' } 1`] = `"4,294,967,296 Eb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'exabit-humanized' } 1`] = `"0 Eb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'exabit-per-second' } 1`] = `"4,294,967,296 Ebps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'exabit-per-second-humanized' } 1`] = `"0 Ebps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'exabyte' } 1`] = `"4,294,967,296 EB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'exabyte-humanized' } 1`] = `"0 EB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'gigabit' } 1`] = `"4,294,967,296 Gb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'gigabit-humanized' } 1`] = `"4 Gb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'gigabit-per-second' } 1`] = `"4,294,967,296 Gbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'gigabit-per-second-humanized' } 1`] = `"4 Gbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'gigabyte' } 1`] = `"4,294,967,296 GB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'gigabyte-humanized' } 1`] = `"4 GB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'kilobit' } 1`] = `"4,294,967,296 Kb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'kilobit-humanized' } 1`] = `"4,194,304 Kb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'kilobit-per-second' } 1`] = `"4,294,967,296 Kbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'kilobit-per-second-humanized' } 1`] = `"4,194,304 Kbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'kilobyte' } 1`] = `"4,294,967,296 KB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'kilobyte-humanized' } 1`] = `"4,194,304 KB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'megabit' } 1`] = `"4,294,967,296 Mb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'megabit-humanized' } 1`] = `"4,096 Mb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'megabit-per-second' } 1`] = `"4,294,967,296 Mbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'megabit-per-second-humanized' } 1`] = `"4,096 Mbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'megabyte' } 1`] = `"4,294,967,296 MB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'megabyte-humanized' } 1`] = `"4,096 MB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'petabit' } 1`] = `"4,294,967,296 Pb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'petabit-humanized' } 1`] = `"0 Pb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'petabit-per-second' } 1`] = `"4,294,967,296 Pbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'petabit-per-second-humanized' } 1`] = `"0 Pbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'petabyte' } 1`] = `"4,294,967,296 PB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'petabyte-humanized' } 1`] = `"0 PB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'terabit' } 1`] = `"4,294,967,296 Tb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'terabit-humanized' } 1`] = `"0 Tb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'terabit-per-second' } 1`] = `"4,294,967,296 Tbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'terabit-per-second-humanized' } 1`] = `"0 Tbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'terabyte' } 1`] = `"4,294,967,296 TB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'terabyte-humanized' } 1`] = `"0 TB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'yottabit' } 1`] = `"4,294,967,296 Yb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'yottabit-humanized' } 1`] = `"0 Yb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'yottabit-per-second' } 1`] = `"4,294,967,296 Ybps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'yottabit-per-second-humanized' } 1`] = `"0 Ybps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'yottabyte' } 1`] = `"4,294,967,296 YB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'yottabyte-humanized' } 1`] = `"0 YB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'zettabit' } 1`] = `"4,294,967,296 Zb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'zettabit-humanized' } 1`] = `"0 Zb"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'zettabit-per-second' } 1`] = `"4,294,967,296 Zbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'zettabit-per-second-humanized' } 1`] = `"0 Zbps"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'zettabyte' } 1`] = `"4,294,967,296 ZB"`;
+
+exports[`formatUnit should work with base { base: 2, unit: 'zettabyte-humanized' } 1`] = `"0 ZB"`;
+
 exports[`formatUnit should work with locale en and { unit: 'bit' } 1`] = `"12.56 b"`;
 
 exports[`formatUnit should work with locale en and { unit: 'bit-humanized' } 1`] = `"13 b"`;

--- a/packages/use-i18n/src/__tests__/formatUnit.ts
+++ b/packages/use-i18n/src/__tests__/formatUnit.ts
@@ -44,6 +44,12 @@ const tests: TestType[] = [
     'fr',
     12,
   ]),
+  ...SUPPORTED_UNITS.map<TestType>(unit => [
+    'should work with base',
+    { base: 2, unit },
+    'en',
+    4294967296, // 4 GB
+  ]),
 ]
 
 describe('formatUnit', () => {

--- a/packages/use-i18n/src/formatUnit.ts
+++ b/packages/use-i18n/src/formatUnit.ts
@@ -137,10 +137,12 @@ const format =
       maximumFractionDigits,
       minimumFractionDigits,
       short = true,
+      base = 10,
     }: {
       maximumFractionDigits?: number
       minimumFractionDigits?: number
       short?: boolean
+      base?: number
     },
   ): string => {
     let computedExponent = exponent
@@ -149,7 +151,7 @@ const format =
     if (humanize) {
       if (computedExponent) {
         const value = filesize(amount, {
-          base: 10,
+          base,
           exponent: exponents.findIndex(
             exp => exp.name === (computedExponent as Exponent).name,
           ),
@@ -159,7 +161,7 @@ const format =
         computedValue = value.value
       } else {
         const value = filesize(amount, {
-          base: 10,
+          base,
           output: 'object',
           round: maximumFractionDigits,
         }) as unknown as { value: number; symbol: string; exponent: number }
@@ -248,6 +250,9 @@ export const supportedUnits: Partial<
 export type FormatUnitOptions = {
   unit: SupportedUnits
   short?: boolean
+  maximumFractionDigits?: number
+  minimumFractionDigits?: number
+  base?: number
 }
 
 const formatUnit = (

--- a/packages/use-i18n/src/formatUnit.ts
+++ b/packages/use-i18n/src/formatUnit.ts
@@ -249,9 +249,15 @@ export const supportedUnits: Partial<
 
 export type FormatUnitOptions = {
   unit: SupportedUnits
+  /**
+    default: true
+  */
   short?: boolean
   maximumFractionDigits?: number
   minimumFractionDigits?: number
+  /**
+    default: 10
+  */
   base?: number
 }
 


### PR DESCRIPTION
Allow to specify a base (other than 10) on formatUnit function.

This way 4294967296 can format to 4 GB for example.