### PR TITLE
ci(ci job): handle github action workflows for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   typecheck:


### PR DESCRIPTION
## Why

With @philibea we discusses that the repository ci workflow was not _fork ready_.
It could be really nice to let to the maintainer the possibility to trigger workflows on open source, external contributions.

## How

In order to let it work, we need to listen to the pull request event as open source contribution are not `push` on original repository.

