### PR TITLE
docs(changeset): fixup changeset for growthbook package init

### DIFF
--- a/.changeset/pr-growthbook.md
+++ b/.changeset/pr-growthbook.md
@@ -1,5 +1,5 @@
 ---
-'@scaleway/ab-test': major
+'@scaleway/use-growthbook': major
 ---
 
 Initialize the AB test common package for integration of GrowthBook inside Scaleway frontend apps


### PR DESCRIPTION
## Why

The changeset I wrote in my PR refer to incorrect name of package before review was applied.
This make the release job fail on main branch. See here https://github.com/scaleway/scaleway-lib/actions/runs/5782763966

## How

- change name of changeset file starting with pr
- change the name of the declared package to match existing one