### PR TITLE
fix(use-i18n): oom when running eslint

### DIFF
--- a/.changeset/chilly-tigers-bathe.md
+++ b/.changeset/chilly-tigers-bathe.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/use-i18n': patch
+---
+
+Fix OOM when running eslint

--- a/packages/use-i18n/src/types.ts
+++ b/packages/use-i18n/src/types.ts
@@ -3,10 +3,15 @@ import type {
   LocaleKeys,
   LocaleValue,
   Params,
-  ScopedValue,
   Scopes,
 } from 'international-types'
 import type { ReactNode } from 'react'
+
+export type ScopedValue<
+  Locale extends BaseLocale,
+  Scope extends Scopes<Locale> | undefined,
+  Key extends LocaleKeys<Locale, Scope>,
+> = Scope extends undefined ? Locale[Key] : Locale[`${Scope}.${Key}`]
 
 export type ReactParamsObject<Value extends LocaleValue> = Record<
   Params<Value>[number],


### PR DESCRIPTION
Not sure why there is an OOM when running eslint but not when running tsc.

```ts
// Before
export type ScopedValue<Locale extends BaseLocale, Scope extends Scopes<Locale> | undefined, Key extends LocaleKeys<Locale, Scope>> = Scope extends undefined ? IsPlural<Key, Locale> extends true ? Locale[`${Key}#${PluralSuffix}`] : Locale[Key] : IsPlural<Key, Locale> extends true ? Locale[`${Scope}.${Key}#${PluralSuffix}`] : Locale[`${Scope}.${Key}`];

// After
export type ScopedValue<Locale extends BaseLocale, Scope extends Scopes<Locale> | undefined, Key extends LocaleKeys<Locale, Scope>> = Scope extends undefined ? Locale[Key] : Locale[`${Scope}.${Key}`];
```