### PR TITLE
chore(random-name): use backward compatible module and types configuration

### DIFF
--- a/packages/random-name/package.json
+++ b/packages/random-name/package.json
@@ -7,10 +7,8 @@
     "node": ">=14.x"
   },
   "sideEffects": false,
-  "exports": {
-    "types": "./dist/index.d.ts",
-    "default": "./dist/index.js"
-  },
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
The current way of resolving modules is resulting in issues with eslint ([example](https://github.com/scaleway/scaleway-sdk-js/actions/runs/6169349622/job/16743432874?pr=819)).

Setting the module and types path the same way as `@scaleway/configuration-loader` is working (it's backward compatible).