### PR TITLE
feat(use-growthbook): export type on provider init

### DIFF
--- a/.changeset/few-peas-dream.md
+++ b/.changeset/few-peas-dream.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/use-growthbook': patch
+---
+
+Export directly some usable type on provider init attributes

--- a/packages/use-growthbook/src/AbTestProvider.tsx
+++ b/packages/use-growthbook/src/AbTestProvider.tsx
@@ -11,11 +11,13 @@ export type ToolConfig = {
 
 export type TrackingCallback = NonNullable<Context['trackingCallback']>
 
+export type ErrorCallback = (error: Error | string) => void
+
 export type AbTestProviderProps = {
   children: ReactNode
   config: ToolConfig
   trackingCallback: TrackingCallback
-  errorCallback: (error: Error | string) => void
+  errorCallback: ErrorCallback
   attributes: Attributes
   loadConfig?: LoadConfig
 }

--- a/packages/use-growthbook/src/index.ts
+++ b/packages/use-growthbook/src/index.ts
@@ -13,3 +13,8 @@ export type {
 } from '@growthbook/growthbook-react'
 export { useAbTestAttributes } from './useAbTestAttributes'
 export { AbTestProvider } from './AbTestProvider'
+export type {
+  TrackingCallback,
+  ErrorCallback,
+  ToolConfig,
+} from './AbTestProvider'


### PR DESCRIPTION
## Why

I face missing exported types from the provider in order to easily declare them.
We could counter by getting them from AbTestProvider.


## How

- export two types from callback

