### PR TITLE
feat(cookie-consent): pass cookie options when deleting one consent

### DIFF
--- a/.changeset/silver-camels-worry.md
+++ b/.changeset/silver-camels-worry.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/cookie-consent': patch
+---
+
+Pass cookie options when removing consent for a specific category

--- a/packages/cookie-consent/src/CookieConsentProvider/CookieConsentProvider.tsx
+++ b/packages/cookie-consent/src/CookieConsentProvider/CookieConsentProvider.tsx
@@ -152,6 +152,7 @@ export const CookieConsentProvider = ({
         if (!consentValue) {
           // If consent is set to false we have to delete the cookie
           document.cookie = cookie.serialize(cookieName, '', {
+            ...cookiesOptions,
             expires: new Date(0),
           })
         } else {

--- a/packages/cookie-consent/src/CookieConsentProvider/CookieConsentProvider.tsx
+++ b/packages/cookie-consent/src/CookieConsentProvider/CookieConsentProvider.tsx
@@ -22,7 +22,7 @@ const CONSENT_MAX_AGE = 13 * 30 * 24 * 60 * 60
 // Appx 6 Months
 const CONSENT_ADVERTISING_MAX_AGE = 6 * 30 * 24 * 60 * 60
 
-export const COOKIES_OPTIONS = {
+const COOKIES_OPTIONS = {
   sameSite: 'strict',
   secure: true,
   path: '/',

--- a/packages/cookie-consent/src/CookieConsentProvider/CookieConsentProvider.tsx
+++ b/packages/cookie-consent/src/CookieConsentProvider/CookieConsentProvider.tsx
@@ -22,7 +22,7 @@ const CONSENT_MAX_AGE = 13 * 30 * 24 * 60 * 60
 // Appx 6 Months
 const CONSENT_ADVERTISING_MAX_AGE = 6 * 30 * 24 * 60 * 60
 
-const COOKIES_OPTIONS = {
+export const COOKIES_OPTIONS = {
   sameSite: 'strict',
   secure: true,
   path: '/',

--- a/packages/cookie-consent/src/CookieConsentProvider/__tests__/index.tsx
+++ b/packages/cookie-consent/src/CookieConsentProvider/__tests__/index.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, jest } from '@jest/globals'
 import { act, renderHook } from '@testing-library/react'
 import cookie from 'cookie'
 import type { ComponentProps, ReactNode } from 'react'
-import { CookieConsentProvider, useCookieConsent } from '..'
+import { COOKIES_OPTIONS, CookieConsentProvider, useCookieConsent } from '..'
 
 const wrapper =
   ({
@@ -240,5 +240,37 @@ describe('CookieConsent - CookieConsentProvider', () => {
       Salesforce: true,
       'Salesforce custom destination (Scaleway)': true,
     })
+  })
+
+  it('should delete a cookie correctly with appropriate options', () => {
+    const spy = jest.spyOn(cookie, 'serialize')
+
+    const { result } = renderHook(() => useCookieConsent(), {
+      wrapper: wrapper({
+        isConsentRequired: true,
+        essentialIntegrations: ['Deskpro', 'Stripe', 'Sentry'],
+        config: {
+          segment: {
+            cdnURL: 'url',
+            writeKey: 'key',
+          },
+        },
+      }),
+    })
+
+    act(() => {
+      result.current.saveConsent({ marketing: false })
+    })
+
+    const expectedDeleteCookieOptions = {
+      ...COOKIES_OPTIONS,
+      expires: expect.any(Date),
+    }
+
+    expect(spy).toHaveBeenCalledWith(
+      '_scw_rgpd_marketing',
+      '',
+      expectedDeleteCookieOptions,
+    )
   })
 })

--- a/packages/cookie-consent/src/CookieConsentProvider/__tests__/index.tsx
+++ b/packages/cookie-consent/src/CookieConsentProvider/__tests__/index.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, jest } from '@jest/globals'
 import { act, renderHook } from '@testing-library/react'
 import cookie from 'cookie'
 import type { ComponentProps, ReactNode } from 'react'
-import { COOKIES_OPTIONS, CookieConsentProvider, useCookieConsent } from '..'
+import { CookieConsentProvider, useCookieConsent } from '..'
 
 const wrapper =
   ({
@@ -149,18 +149,16 @@ describe('CookieConsent - CookieConsentProvider', () => {
       })
     })
 
-    const cookieOptions = { sameSite: 'strict', secure: true }
+    const cookieOptions = { sameSite: 'strict', secure: true, path: '/' }
 
     expect(spy).toHaveBeenCalledTimes(3)
     expect(spy).toHaveBeenNthCalledWith(2, '_scw_rgpd_marketing', 'true', {
       ...cookieOptions,
       maxAge: 33696000,
-      path: '/',
     })
     expect(spy).toHaveBeenNthCalledWith(3, '_scw_rgpd_hash', '913003917', {
       ...cookieOptions,
       maxAge: 15552000,
-      path: '/',
     })
 
     act(() => {
@@ -172,12 +170,12 @@ describe('CookieConsent - CookieConsentProvider', () => {
 
     expect(spy).toHaveBeenCalledTimes(6)
     expect(spy).toHaveBeenNthCalledWith(5, '_scw_rgpd_marketing', '', {
+      ...cookieOptions,
       expires: new Date(0),
     })
     expect(spy).toHaveBeenNthCalledWith(6, '_scw_rgpd_hash', '913003917', {
       ...cookieOptions,
       maxAge: 15552000,
-      path: '/',
     })
   })
 
@@ -240,37 +238,5 @@ describe('CookieConsent - CookieConsentProvider', () => {
       Salesforce: true,
       'Salesforce custom destination (Scaleway)': true,
     })
-  })
-
-  it('should delete a cookie correctly with appropriate options', () => {
-    const spy = jest.spyOn(cookie, 'serialize')
-
-    const { result } = renderHook(() => useCookieConsent(), {
-      wrapper: wrapper({
-        isConsentRequired: true,
-        essentialIntegrations: ['Deskpro', 'Stripe', 'Sentry'],
-        config: {
-          segment: {
-            cdnURL: 'url',
-            writeKey: 'key',
-          },
-        },
-      }),
-    })
-
-    act(() => {
-      result.current.saveConsent({ marketing: false })
-    })
-
-    const expectedDeleteCookieOptions = {
-      ...COOKIES_OPTIONS,
-      expires: expect.any(Date),
-    }
-
-    expect(spy).toHaveBeenCalledWith(
-      '_scw_rgpd_marketing',
-      '',
-      expectedDeleteCookieOptions,
-    )
   })
 })

--- a/packages/cookie-consent/src/CookieConsentProvider/index.tsx
+++ b/packages/cookie-consent/src/CookieConsentProvider/index.tsx
@@ -1,6 +1,7 @@
 export {
   CookieConsentProvider,
   useCookieConsent,
+  COOKIES_OPTIONS,
 } from './CookieConsentProvider'
 export type { CategoryKind, Consent } from './types'
 export { useSegmentIntegrations } from './useSegmentIntegrations'

--- a/packages/cookie-consent/src/CookieConsentProvider/index.tsx
+++ b/packages/cookie-consent/src/CookieConsentProvider/index.tsx
@@ -1,7 +1,6 @@
 export {
   CookieConsentProvider,
   useCookieConsent,
-  COOKIES_OPTIONS,
 } from './CookieConsentProvider'
 export type { CategoryKind, Consent } from './types'
 export { useSegmentIntegrations } from './useSegmentIntegrations'


### PR DESCRIPTION
## Why

We were having an issue on localhost when trying to remove a cookie. It wasn't always working, apparently we need to pass the path (cookie options in our case) to make it work. You can have more info by clicking on the lint below

https://stackoverflow.com/a/28119715 

