### PR TITLE
fix(cookies): bind name for segment integration instead of creationName

### DIFF
--- a/.changeset/brave-needles-play.md
+++ b/.changeset/brave-needles-play.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/cookie-consent': patch
+---
+
+Fix configuration of segment integrations with categories by using name instead of creationName

--- a/packages/cookie-consent/src/CookieConsentProvider/__tests__/useSegmentIntegrations/working.tsx
+++ b/packages/cookie-consent/src/CookieConsentProvider/__tests__/useSegmentIntegrations/working.tsx
@@ -58,7 +58,7 @@ describe('CookieConsent - useSegmentIntegrations', () => {
         },
         {
           category: 'analytics',
-          name: 'Google Analytics',
+          name: 'Google Universal Analytics',
         },
         {
           category: 'marketing',
@@ -70,7 +70,7 @@ describe('CookieConsent - useSegmentIntegrations', () => {
         },
         {
           category: 'marketing',
-          name: 'bonjour',
+          name: 'Scaleway Custom',
         },
       ])
     })

--- a/packages/cookie-consent/src/CookieConsentProvider/useSegmentIntegrations.ts
+++ b/packages/cookie-consent/src/CookieConsentProvider/useSegmentIntegrations.ts
@@ -37,8 +37,8 @@ const transformSegmentIntegrationsToIntegrations = (
   segmentIntegrations: SegmentIntegrations,
 ): Integrations =>
   [defaultSegmentIoIntegration, ...segmentIntegrations].map(
-    ({ category, creationName }) => ({
-      name: creationName,
+    ({ category, name }) => ({
+      name,
       category: CATEGORY_MATCH[category] ?? 'marketing',
     }),
   )


### PR DESCRIPTION
## Why

We have some missing events in Amplitude but we receive them in Segment.
It does seems to be due to the mapping of consent categories with Amplitude.

## How

- [revert modification that introduce an inverted condition here](https://github.com/scaleway/scaleway-lib/pull/1494#discussion_r1332942387) 
- fixup snapshots