### PR TITLE
docs(readme): fixup typos in Readme files

### DIFF
--- a/.changeset/healthy-ghosts-compare.md
+++ b/.changeset/healthy-ghosts-compare.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/cookie-consent': patch
+---
+
+Fix naming error in Readme heading

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ scaleway-lib is a set of NPM packages used at Scaleway.
 
 ## Available packages
 
-## Available packages
-
 - [`@scaleway/cookie-consent`](./packages/countries/README.md): React provider to handle website end user consent cookie storage based on segment integrations.
 
   ![npm](https://img.shields.io/npm/dm/@scaleway/cookie-consent)

--- a/packages/cookie-consent/README.md
+++ b/packages/cookie-consent/README.md
@@ -1,4 +1,4 @@
-# Shire - Cookie Consent
+# `@scaleway/cookie-consent`
 
 This package is an helper to handle cookie consents with Segment integrations.
 It will handle the cookie consent for each categories.


### PR DESCRIPTION
## Why

Found out they were still some small issues in scaleway lib documentation files

## How

- remove duplicated title in global readme file
- rename heading1 of cookie-consent package to remove reference of shire