### PR TITLE
refactor(type-test): use new runner for types tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,15 +52,13 @@ jobs:
       - run: pnpm install
       - run: pnpm run build
       - run: pnpm run test:coverage
-<<<<<<< HEAD
       - uses: codecov/codecov-action@v4.1.1
-=======
-      - uses: codecov/codecov-action@v3.1.4
+
   test-types:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node: ['18','20']
+        node: ['20']
     steps:
       - uses: actions/checkout@v4.1.1
       - uses: pnpm/action-setup@v2.4.0
@@ -74,4 +72,3 @@ jobs:
       - run: pnpm run build
       - run: pnpm run test:types
 
->>>>>>> e23dfe49 (refactor(type-test): use new runner for types tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,26 @@ jobs:
       - run: pnpm install
       - run: pnpm run build
       - run: pnpm run test:coverage
+<<<<<<< HEAD
       - uses: codecov/codecov-action@v4.1.1
+=======
+      - uses: codecov/codecov-action@v3.1.4
+  test-types:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node: ['18','20']
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - uses: pnpm/action-setup@v2.4.0
+      - name: Use Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: ${{ matrix.node }}
+          check-latest: true
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm run build
+      - run: pnpm run test:types
+
+>>>>>>> e23dfe49 (refactor(type-test): use new runner for types tests)

--- a/jest.config.tsd.mjs
+++ b/jest.config.tsd.mjs
@@ -1,8 +1,0 @@
-export default {
-  displayName: {
-    color: 'blue',
-    name: 'types',
-  },
-  runner: 'jest-runner-tsd',
-  testMatch: ['**/__typetests__/*.test.ts'],
-};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@scaleway/tsconfig": "workspace:*",
     "@testing-library/jest-dom": "6.4.2",
     "@testing-library/react": "14.2.2",
-    "@tsd/typescript": "5.3.3",
     "@types/jest": "29.5.12",
     "@types/node": "20.11.30",
     "@types/react": "18.2.67",
@@ -52,7 +51,7 @@
     "rollup-plugin-dts": "6.1.0",
     "rollup-plugin-preserve-shebangs": "0.2.0",
     "rollup-plugin-visualizer": "5.12.0",
-    "tsd-lite": "0.8.2",
+    "tstyche": "1.1.0 ",
     "typescript": "5.4.3",
     "wait-for-expect": "3.0.2"
   },
@@ -66,7 +65,7 @@
     "test": "TZ=UTC jest",
     "test:watch": "pnpm run test --watch",
     "test:coverage": "pnpm run test --coverage",
-    "test:types": "jest -c jest.config.tsd.mjs",
+    "test:types": "tstyche",
     "release": "pnpm build && pnpm changeset publish",
     "prepare": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "jest-environment-jsdom": "29.7.0",
     "jest-junit": "16.0.0",
     "jest-localstorage-mock": "2.4.26",
-    "jest-runner-tsd": "6.0.0",
     "lint-staged": "15.2.2",
     "mockdate": "3.0.5",
     "prettier": "3.2.5",

--- a/packages/use-i18n/src/__typetests__/namespaceTranslation.test.ts
+++ b/packages/use-i18n/src/__typetests__/namespaceTranslation.test.ts
@@ -1,56 +1,69 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import { expectError, expectType } from 'tsd-lite'
+import { expect, test } from 'tstyche'
 import { useI18n } from '../usei18n'
 
-const { namespaceTranslation } = useI18n<{
-  hello: 'world'
-  'doe.john': 'John Doe'
-  'doe.jane': 'Jane Doe'
-  'doe.child': 'Child is {name}'
-  'describe.john': '{name} is {age} years old'
-}>()
+test('i18n - namespaceTranslation', () => {
+  const { namespaceTranslation } = useI18n<{
+    hello: 'world'
+    'doe.john': 'John Doe'
+    'doe.jane': 'Jane Doe'
+    'doe.child': 'Child is {name}'
+    'describe.john': '{name} is {age} years old'
+  }>()
 
-// Single key
-expectError(namespaceTranslation('hello'))
+  // Single key
+  expect(namespaceTranslation('hello')).type.toRaiseError(
+    `Argument of type '"hello"' is not assignable to parameter of type '"doe" | "describe"'`,
+  )
 
-// Multiple keys
-expectError(namespaceTranslation('doe.john'))
-const scopedT1 = namespaceTranslation('doe')
-expectType<string>(scopedT1('john'))
-expectError(scopedT1('doesnotexists'))
+  // Multiple keys
+  expect(namespaceTranslation('doe.john')).type.toRaiseError(
+    `Argument of type '"doe.john"' is not assignable to parameter of type '"doe" | "describe"'`,
+  )
 
-// With a param
-const scopedT2 = namespaceTranslation('doe')
-expectError(scopedT2('child'))
-expectType<string>(
-  scopedT2('child', {
-    name: 'Name',
-  }),
-)
-expectError(
-  scopedT2('doesnotexists', {
-    name: 'Name',
-  }),
-)
-expectError(
-  scopedT2('child', {
-    doesnotexists: 'Name',
-  }),
-)
-expectError(scopedT2('child', {}))
-expectError(scopedT2('child'))
+  expect(namespaceTranslation('doe')('john')).type.toEqual<string>()
 
-// With multiple params
-const scopedT3 = namespaceTranslation('describe')
-expectType<string>(
-  scopedT3('john', {
-    age: '30',
-    name: 'John',
-  }),
-)
-expectError(scopedT3('john', {}))
-expectError(scopedT3('john'))
+  expect(namespaceTranslation('doe')('doesnotexists')).type.toRaiseError(
+    `Expected 2 arguments, but got 1.`,
+  )
 
-// Required generic
-const { namespaceTranslation: namespaceTranslation2 } = useI18n()
-expectError(namespaceTranslation2('test'))
+  // With a param
+  expect(namespaceTranslation('doe')('child')).type.toRaiseError(
+    `Expected 2 arguments, but got 1.`,
+  )
+  expect(
+    namespaceTranslation('doe')('child', {
+      name: 'Name',
+    }),
+  ).type.toEqual<string>()
+  expect(
+    namespaceTranslation('doe')('doesnotexists', {
+      name: 'Name',
+    }),
+  ).type.toRaiseError()
+  expect(
+    namespaceTranslation('doe')('child', {
+      doesnotexists: 'Name',
+    }),
+  ).type.toRaiseError()
+
+  expect(namespaceTranslation('doe')('child', {})).type.toRaiseError()
+  expect(namespaceTranslation('doe')('child')).type.toRaiseError()
+
+  // With multiple params
+  expect(
+    namespaceTranslation('describe')('john', {
+      age: '30',
+      name: 'John',
+    }),
+  ).type.toEqual<string>()
+
+  expect(namespaceTranslation('describe')('john', {})).type.toRaiseError()
+  expect(namespaceTranslation('describe')('john')).type.toRaiseError()
+
+  // Required generic
+  const { namespaceTranslation: namespaceTranslation2 } = useI18n()
+  expect(namespaceTranslation2('test')).type.toRaiseError(
+    `Argument of type '"test"' is not assignable to parameter of type`,
+  )
+})

--- a/packages/use-i18n/src/__typetests__/t.test.tsx
+++ b/packages/use-i18n/src/__typetests__/t.test.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable react-hooks/rules-of-hooks */
-import { expectError, expectType } from 'tsd-lite'
-import { useI18n, useTranslation } from '../usei18n'
+import { expect, test } from 'tstyche'
+import { useI18n } from '../usei18n'
 
 const { t } = useI18n<{
   hello: 'world'
@@ -10,55 +9,56 @@ const { t } = useI18n<{
   'describe.john': '{name} is {age} years old'
 }>()
 
-// Single key
-expectType<string>(t('hello'))
-expectError(t('keydoesnotexists'))
+test('i18n - t', () => {
+  expect(t('hello')).type.toEqual<string>()
+  // Single key
+  expect(t('keydoesnotexists')).type.toRaiseError()
 
-// Multiple keys
-expectType<string>(t('doe.john'))
-expectError(t('doe.doesnotexists'))
+  // Multiple keys
+  expect(t('doe.john')).type.toEqual<string>()
+  expect(t('doe.doesnotexists')).type.toRaiseError()
 
-// With a param
-expectError(t('doe.child'))
-expectType<string>(
-  t('doe.child', {
-    name: 'Name',
-  }),
-)
-expectError(
-  t('doe.doesnotexists', {
-    name: 'Name',
-  }),
-)
-expectError(
-  t('doe.child', {
-    doesnotexists: 'Name',
-  }),
-)
-expectError(t('doe.child', {}))
-expectError(t('doe.child'))
+  // With a param
+  expect(
+    t('doe.child', {
+      name: 'Name',
+    }),
+  ).type.toEqual<string>()
+  expect(
+    t('doe.doesnotexists', {
+      name: 'Name',
+    }),
+  ).type.toRaiseError()
 
-// With multiple params
-expectType<string>(
-  t('describe.john', {
-    age: '30',
-    name: 'John',
-  }),
-)
-expectError(t('describe.john', {}))
-expectError(t('describe.john'))
+  expect(t('doe.child', {})).type.toRaiseError(
+    "Argument of type '{}' is not assignable to parameter of type",
+  )
 
-// With react components as param value
-expectType<string>(
-  t('doe.child', {
-    name: (
-      <p>
-        My name is<b>John</b>
-      </p>
-    ),
-  }),
-)
+  expect(t('doe.child')).type.toRaiseError('Expected 2 arguments, but got 1')
 
-// Required generic
-const { t: t2 } = useI18n()
-expectError(t2('test'))
+  // With multiple params
+  expect(
+    t('describe.john', {
+      age: '30',
+      name: 'John',
+    }),
+  ).type.toEqual<string>()
+
+  expect(t('describe.john', {})).type.toRaiseError()
+  expect(t('describe.john')).type.toRaiseError()
+
+  // With react components as param value
+  expect(
+    t('doe.child', {
+      name: (
+        <p>
+          My name is<b>John</b>
+        </p>
+      ),
+    }),
+  ).type.toEqual<string>()
+
+  // Required generic
+  const { t: t2 } = useI18n()
+  expect(t2('test')).type.toRaiseError()
+})

--- a/packages/use-i18n/src/__typetests__/tsconfig.json
+++ b/packages/use-i18n/src/__typetests__/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "types": []
+  },
+  "include": ["./"],
+  "exclude": []
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,6 @@ importers:
       '@testing-library/react':
         specifier: 14.2.2
         version: 14.2.2(react-dom@18.2.0)(react@18.2.0)
-      '@tsd/typescript':
-        specifier: 5.3.3
-        version: 5.3.3
       '@types/jest':
         specifier: 29.5.12
         version: 29.5.12
@@ -131,9 +128,9 @@ importers:
       rollup-plugin-visualizer:
         specifier: 5.12.0
         version: 5.12.0(rollup@4.13.2)
-      tsd-lite:
-        specifier: 0.8.2
-        version: 0.8.2(@tsd/typescript@5.3.3)
+      tstyche:
+        specifier: '1.1.0 '
+        version: 1.1.0(typescript@5.4.3)
       typescript:
         specifier: 5.4.3
         version: 5.4.3
@@ -9626,6 +9623,19 @@ packages:
   /tslib@2.5.3:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
     dev: false
+
+  /tstyche@1.1.0(typescript@5.4.3):
+    resolution: {integrity: sha512-ZvDeScrBJf6053bdOkGUtnfDn7414XjmjGWrDntQfSmtPvxv9HVJ+03GFK2O46hfoAI9L5Q22uw6xy5ZTBdPGg==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    peerDependencies:
+      typescript: 4.x || 5.x
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.4.3
+    dev: true
 
   /tsutils@3.21.0(typescript@5.4.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,9 +95,6 @@ importers:
       jest-localstorage-mock:
         specifier: 2.4.26
         version: 2.4.26
-      jest-runner-tsd:
-        specifier: 6.0.0
-        version: 6.0.0(@tsd/typescript@5.3.3)
       lint-staged:
         specifier: 15.2.2
         version: 15.2.2
@@ -363,13 +360,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
-    dev: true
-
-  /@babel/code-frame@7.22.5:
-    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': 7.23.4
     dev: true
 
   /@babel/code-frame@7.23.5:
@@ -665,16 +655,6 @@ packages:
       '@babel/types': 7.24.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@babel/highlight@7.23.4:
-    resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
-    engines: {node: '>=6.9.0'}
-    requiresBuild: true
-    dependencies:
-      '@babel/helper-validator-identifier': 7.22.20
-      chalk: 2.4.2
-      js-tokens: 4.0.0
     dev: true
 
   /@babel/highlight@7.24.2:
@@ -4092,11 +4072,6 @@ packages:
     engines: {node: '>= 10'}
     dev: true
 
-  /@tsd/typescript@5.3.3:
-    resolution: {integrity: sha512-CQlfzol0ldaU+ftWuG52vH29uRoKboLinLy84wS8TQOu+m+tWoaUfk4svL4ij2V8M5284KymJBlHUusKj6k34w==}
-    engines: {node: '>=14.17'}
-    dev: true
-
   /@types/aria-query@5.0.1:
     resolution: {integrity: sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==}
 
@@ -5200,23 +5175,6 @@ packages:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       typescript: 5.4.3
-    dev: true
-
-  /create-jest-runner@0.12.3:
-    resolution: {integrity: sha512-xrGcSrr86F2YdbrOoAZIowSYMYBpxrOrqHEvJqIpG0vsuMVcq3+OKSe7JJR1SWJFLGiMhHInPyR48+rW9ZHq9Q==}
-    hasBin: true
-    peerDependencies:
-      '@jest/test-result': ^28.0.0 || ^29.0.0
-      jest-runner: ^28.0.0 || ^29.0.0
-    peerDependenciesMeta:
-      '@jest/test-result':
-        optional: true
-      jest-runner:
-        optional: true
-    dependencies:
-      chalk: 4.1.2
-      jest-worker: 29.6.4
-      p-limit: 3.1.0
     dev: true
 
   /create-jest@29.7.0(@types/node@20.11.30):
@@ -7576,22 +7534,6 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /jest-runner-tsd@6.0.0(@tsd/typescript@5.3.3):
-    resolution: {integrity: sha512-lSzRoVqc/AwahlKFamdwO/R63Vze/xpCnab+FsNni8zmxyBt3e3py51mFE2UQBh2gSvEYwudOSHgX+xtmLynKw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@tsd/typescript': 4.x || 5.x
-    dependencies:
-      '@babel/code-frame': 7.22.5
-      '@tsd/typescript': 5.3.3
-      chalk: 4.1.2
-      create-jest-runner: 0.12.3
-      tsd-lite: 0.8.2(@tsd/typescript@5.3.3)
-    transitivePeerDependencies:
-      - '@jest/test-result'
-      - jest-runner
-    dev: true
-
   /jest-runner@29.7.0:
     resolution: {integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7679,18 +7621,6 @@ packages:
       - supports-color
     dev: true
 
-  /jest-util@29.6.3:
-    resolution: {integrity: sha512-QUjna/xSy4B32fzcKTSz1w7YYzgiHrjjJjevdRf61HYk998R5vVMMNmrHESYZVDS5DSWs+1srPLPKxXPkeSDOA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/types': 29.6.3
-      '@types/node': 20.11.30
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      graceful-fs: 4.2.11
-      picomatch: 2.3.1
-    dev: true
-
   /jest-util@29.7.0:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7726,16 +7656,6 @@ packages:
       emittery: 0.13.1
       jest-util: 29.7.0
       string-length: 4.0.2
-    dev: true
-
-  /jest-worker@29.6.4:
-    resolution: {integrity: sha512-6dpvFV4WjcWbDVGgHTWo/aupl8/LbBx2NSKfiwqf79xC/yeJjKHT1+StcKy/2KTmW16hE68ccKVOtXf+WZGz7Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@types/node': 20.11.30
-      jest-util: 29.6.3
-      merge-stream: 2.0.0
-      supports-color: 8.1.1
     dev: true
 
   /jest-worker@29.7.0:
@@ -9606,15 +9526,6 @@ packages:
       minimist: 1.2.8
       strip-bom: 3.0.0
     dev: false
-
-  /tsd-lite@0.8.2(@tsd/typescript@5.3.3):
-    resolution: {integrity: sha512-A1bzKLlQoWf6NkavfxYqOkbRL/B/kYsBDGUNyXqXm193mAbiXoIJxOjd84CIQ/B2dtxcy8dHat+6V//zxpGBmA==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@tsd/typescript': 4.x || 5.x
-    dependencies:
-      '@tsd/typescript': 5.3.3
-    dev: true
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,3 +1,0 @@
-{
-  "testFileMatch": ["**/__typetests__/*.test.ts", "**/__typetests__/*.test.tsx"]
-}

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,0 +1,3 @@
+{
+  "testFileMatch": ["**/__typetests__/*.test.ts", "**/__typetests__/*.test.tsx"]
+}


### PR DESCRIPTION
Migration from "tsd-lite" to "tstyche".

waiting https://github.com/tstyche/tstyche/issues/17

close https://github.com/scaleway/scaleway-lib/pull/1658