### PR TITLE
fix(use-i18n): add non async loadDateLocalFns 

### DIFF
--- a/.changeset/nice-seahorses-protect.md
+++ b/.changeset/nice-seahorses-protect.md
@@ -1,0 +1,5 @@
+---
+"@scaleway/use-i18n": minor
+---
+
+Add a non async loadDateLocal possibility


### PR DESCRIPTION
Add the possibility to avoid useless re-render at first render of the provider,  i add  a`loadDateLocale` props which is non async and will act as a default value of dateFns based on the current value of the user.

```javascript
   loadDateLocaleAsync = async (locale: string) => {
      if (locale === 'en') {
        return (await import('date-fns/locale/en-GB')).enGB
      }
      if (locale === 'fr') {
        return (await import('date-fns/locale/fr')).fr
      }

      if (locale === 'es') {
        return (await import('date-fns/locale/es')).es
      }

      return (await import(`date-fns/locale/en-GB`)).enGB
    },
```

```javascript
import { enGB, fr as frDateFns } from 'date-fns/locale'

 loadDateLocale = (locale: string) => {
      if (locale === 'en') {
        return enGB
      }
      if (locale === 'fr') {
        return frDateFns
      }

      return enGB
    },
```