### PR TITLE
fix(random-name): add xavier niel for consistency with scaleway-sdk-go

### DIFF
--- a/.changeset/chatty-lemons-return.md
+++ b/.changeset/chatty-lemons-return.md
@@ -1,0 +1,5 @@
+---
+"@scaleway/random-name": patch
+---
+
+Add Xavier Niel on random name

--- a/packages/random-name/src/index.ts
+++ b/packages/random-name/src/index.ts
@@ -613,6 +613,9 @@ const NAMES = [
   // Isaac Newton invented classic mechanics and modern optics. https://en.wikipedia.org/wiki/Isaac_Newton
   'newton',
 
+  // Xavier Niel - ;) https://en.wikipedia.org/wiki/Xavier_Niel
+  'niel',
+
   // Florence Nightingale, more prominently known as a nurse, was also the first female member of the Royal Statistical Society and a pioneer in statistical graphics https://en.wikipedia.org/wiki/Florence_Nightingale#Statistics_and_sanitary_reform
   'nightingale',
 


### PR DESCRIPTION
When generating a random name for a resource, we have a different standard between the go SDK and scaleway-lib. Specifically, scaleway-lib is missing Xavier Niel as a possible generated name.

This MR fixes it :nerd_face: 

Reference: https://github.com/scaleway/scaleway-sdk-go/blob/master/namegenerator/name_generator.go#L632