### PR TITLE
feat(eslint-config): remove deprecation rule

### DIFF
--- a/.changeset/wet-grapes-eat.md
+++ b/.changeset/wet-grapes-eat.md
@@ -1,0 +1,5 @@
+---
+"@scaleway/eslint-config-react": minor
+---
+
+remove eslint deprecation rule

--- a/packages/eslint-config-react/typescript.js
+++ b/packages/eslint-config-react/typescript.js
@@ -8,7 +8,6 @@ module.exports = {
   ],
   plugins: ['deprecation', '@typescript-eslint'],
   rules: {
-    'deprecation/deprecation': 'warn',
     // Enforce T[] instead of Array<T>
     '@typescript-eslint/array-type': [
       'error',


### PR DESCRIPTION
Remove deprecation rule from eslint as the rule is already handled by typescript.