### PR TITLE
fix(integrations): do not set All by default when integrations are al…

### DIFF
--- a/.changeset/swift-countries-worry.md
+++ b/.changeset/swift-countries-worry.md
@@ -1,0 +1,5 @@
+---
+"@scaleway/cookie-consent": patch
+---
+
+Remove the default object All: false of integrations when integrations are set. This will only apply on empty integrations array to protect users


### PR DESCRIPTION
Remove an Objet All: false when there is more than one integration as we set all categories actully.

Fix test unitaire, test was not properly clear between them.

Avoid unecessary re-redender with a useless state of cookies