### PR TITLE
feat: add legacy main attribut for legacy node applications

### DIFF
--- a/.changeset/new-games-act.md
+++ b/.changeset/new-games-act.md
@@ -1,0 +1,12 @@
+---
+"@scaleway/validate-icu-locales": minor
+"@scaleway/cookie-consent": minor
+"@scaleway/use-dataloader": minor
+"@scaleway/use-growthbook": minor
+"@scaleway/random-name": minor
+"@scaleway/use-segment": minor
+"@scaleway/use-storage": minor
+"@scaleway/regex": minor
+---
+
+add legacy main attribut for CommonJS export usage

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -2,6 +2,7 @@
   "name": "@scaleway/cookie-consent",
   "version": "1.2.4",
   "description": "React provider to handle website end user consent cookie storage based on segment integrations",
+  "main": "./dist/index.cjs",
   "type": "module",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/random-name/package.json
+++ b/packages/random-name/package.json
@@ -6,6 +6,7 @@
     "node": ">=20.x"
   },
   "sideEffects": false,
+  "main": "./dist/index.cjs",
   "type": "module",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/regex/package.json
+++ b/packages/regex/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=20.x"
   },
+  "main": "./dist/index.cjs",
   "sideEffects": false,
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/use-dataloader/package.json
+++ b/packages/use-dataloader/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=20.x"
   },
+  "main": "./dist/index.cjs",
   "sideEffects": false,
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/use-growthbook/package.json
+++ b/packages/use-growthbook/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": ">=20.x"
   },
+  "main": "./dist/index.cjs",
   "sideEffects": false,
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/use-segment/package.json
+++ b/packages/use-segment/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": ">=20.x"
   },
+  "main": "./dist/index.cjs",
   "sideEffects": false,
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/use-storage/package.json
+++ b/packages/use-storage/package.json
@@ -7,6 +7,7 @@
   },
   "sideEffects": false,
   "type": "module",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/validate-icu-locales/package.json
+++ b/packages/validate-icu-locales/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": ">=20.x"
   },
+  "main": "./dist/index.cjs",
   "type": "module",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why

Some of our apps are not yet compatible with `esm` natively and can't use the `module` exported files on server.
In order to to recompile them locally and as they are exported directly, let's add the legacy `main` attribute for retrocompatibility.

Recent package will use `exports` syntax and ignore the main one

## How

- add main on package that have CommonJS exported assets