### PR TITLE
fix(i18n): add default locales from browser to be able to select them

### DIFF
--- a/.changeset/popular-fans-act.md
+++ b/.changeset/popular-fans-act.md
@@ -1,0 +1,5 @@
+---
+"@scaleway/use-i18n": patch
+---
+
+fix default locales browser list

--- a/packages/use-i18n/src/usei18n.tsx
+++ b/packages/use-i18n/src/usei18n.tsx
@@ -53,7 +53,9 @@ const getCurrentLocale = ({
 }): string => {
   if (typeof window !== 'undefined') {
     const { languages } = navigator
-    const browserLocales = [...new Set(languages.map(getLocaleFallback))]
+    const browserLocales = [
+      ...new Set([...languages.map(getLocaleFallback), ...languages]),
+    ]
     const currentLocalFromlocalStorage = localStorage.getItem(localeItemStorage)
 
     if (


### PR DESCRIPTION
currently if files are not named with basic language 2 letters length (such as 'en', 'fr', ...) then default locales are not found.

If we have files matching the languages pattern of browser, such as (fr-FR, en-US, etc) then it was not taken into account.

This PR fix this