### PR TITLE
feat(changesets-renovate): add option to skip branch check

### DIFF
--- a/.changeset/fresh-zebras-eat.md
+++ b/.changeset/fresh-zebras-eat.md
@@ -1,0 +1,5 @@
+---
+"@scaleway/changesets-renovate": minor
+---
+
+Add `SKIP_BRANCH_CHECK` as an option to not check branch name

--- a/packages/changesets-renovate/README.md
+++ b/packages/changesets-renovate/README.md
@@ -22,6 +22,12 @@ To skip committing the changeset.
 SKIP_COMMIT=TRUE changesets-renovate
 ```
 
+To have a custom prefix for renovate branch name instead of `renovate/`
+
+```bash
+BRANCH_PREFIX=dep-upgrade changesets-renovate
+```
+
 To skip checking the branch name starts `renovate/`
 
 ```bash

--- a/packages/changesets-renovate/README.md
+++ b/packages/changesets-renovate/README.md
@@ -22,4 +22,10 @@ To skip committing the changeset.
 SKIP_COMMIT=TRUE changesets-renovate
 ```
 
+To skip checking the branch name starts `renovate/`
+
+```bash
+SKIP_BRANCH_CHECK=TRUE changesets-renovate
+```
+
 It's inspired by this GitHub Action from Backstage: https://github.com/backstage/backstage/blob/master/.github/workflows/sync_renovate-changesets.yml

--- a/packages/changesets-renovate/src/__tests__/__snapshots__/generate-changeset.test.ts.snap
+++ b/packages/changesets-renovate/src/__tests__/__snapshots__/generate-changeset.test.ts.snap
@@ -45,3 +45,49 @@ Updated dependency \`package2\` to \`version2\`.
   ],
 }
 `;
+
+exports[`generate changeset file > should not skip if not in renovate branch, when branch check skip is true 1`] = `
+[MockFunction spy] {
+  "calls": [
+    [
+      ".changeset/renovate-test.md",
+      "---
+'packageName': patch
+---
+
+Updated dependency \`package\` to \`version\`.
+Updated dependency \`package2\` to \`version2\`.
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`generate changeset file > should skip if not in renovate branch 1`] = `
+[MockFunction spy] {
+  "calls": [
+    [
+      ".changeset/renovate-test.md",
+      "---
+'packageName': patch
+---
+
+Updated dependency \`package\` to \`version\`.
+Updated dependency \`package2\` to \`version2\`.
+",
+    ],
+  ],
+  "results": [
+    {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;

--- a/packages/changesets-renovate/src/__tests__/__snapshots__/generate-changeset.test.ts.snap
+++ b/packages/changesets-renovate/src/__tests__/__snapshots__/generate-changeset.test.ts.snap
@@ -46,7 +46,7 @@ Updated dependency \`package2\` to \`version2\`.
 }
 `;
 
-exports[`generate changeset file > should not skip if not in renovate branch, when branch check skip is true 1`] = `
+exports[`generate changeset file > should not skip if branch starts with custom branch prefix 1`] = `
 [MockFunction spy] {
   "calls": [
     [
@@ -69,7 +69,7 @@ Updated dependency \`package2\` to \`version2\`.
 }
 `;
 
-exports[`generate changeset file > should skip if not in renovate branch 1`] = `
+exports[`generate changeset file > should not skip if not in renovate branch, when branch check skip is true 1`] = `
 [MockFunction spy] {
   "calls": [
     [

--- a/packages/changesets-renovate/src/__tests__/generate-changeset.test.ts
+++ b/packages/changesets-renovate/src/__tests__/generate-changeset.test.ts
@@ -25,9 +25,57 @@ describe('generate changeset file', () => {
     expect(console.log).toHaveBeenCalledWith('Not a renovate branch, skipping')
   })
 
-  it('should not skip if not in renovate branch, when branch check skip is true', async () => {
-    process.env['SKIP_BRANCH_CHECK'] = 'TRUE'
+  it('should not skip if branch starts with custom branch prefix', async () => {
+    const rev = 'test'
+    const fileName = `.changeset/renovate-${rev}.md`
+    const file = 'test/package.json'
+    const revparse = vi.fn().mockReturnValue(rev)
+    const add = vi.fn()
+    const commit = vi.fn()
+    const push = vi.fn()
 
+    mockSimpleGit.mockReturnValue({
+      branch: () => ({
+        current: 'dep-upgrade/test',
+      }),
+      diffSummary: () => ({
+        files: [
+          {
+            file,
+          },
+        ],
+      }),
+      show: () => `
++ "package": "version"
++ "package2": "version2"
+`,
+      revparse,
+      add,
+      commit,
+      push,
+    })
+
+    fs.readFile = vi
+      .fn()
+      .mockResolvedValueOnce(`{}`)
+      .mockResolvedValueOnce(`{"name":"packageName","version":"1.0.0"}`)
+    fs.writeFile = vi.fn()
+
+    process.env['BRANCH_PREFIX'] = 'dep-upgrade/'
+    await run()
+    process.env['BRANCH_PREFIX'] = undefined
+
+    expect(console.log).not.toHaveBeenCalledWith(
+      'Not a renovate branch, skipping',
+    )
+    expect(fs.readFile).toHaveBeenCalledWith(file, 'utf8')
+    expect(fs.writeFile).toMatchSnapshot()
+    expect(add).toHaveBeenCalledWith(fileName)
+    expect(commit).toHaveBeenCalledWith(`chore: add changeset renovate-${rev}`)
+    expect(push).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not skip if not in renovate branch, when branch check skip is true', async () => {
     const rev = 'test'
     const fileName = `.changeset/renovate-${rev}.md`
     const file = 'test/package.json'
@@ -63,7 +111,9 @@ describe('generate changeset file', () => {
       .mockResolvedValueOnce(`{"name":"packageName","version":"1.0.0"}`)
     fs.writeFile = vi.fn()
 
+    process.env['SKIP_BRANCH_CHECK'] = 'TRUE'
     await run()
+    process.env['SKIP_BRANCH_CHECK'] = undefined
 
     expect(console.log).not.toHaveBeenCalledWith(
       'Not a renovate branch, skipping',

--- a/packages/changesets-renovate/src/index.ts
+++ b/packages/changesets-renovate/src/index.ts
@@ -94,11 +94,12 @@ async function getBumps(files: string[]): Promise<Map<string, string>> {
 
 export async function run() {
   const branch = await simpleGit().branch()
+  const branchPrefix = process.env['BRANCH_PREFIX'] ?? 'renovate/'
 
   console.log('Detected branch:', branch)
 
   if (
-    !branch.current.startsWith('renovate/') &&
+    !branch.current.startsWith(branchPrefix) &&
     !process.env['SKIP_BRANCH_CHECK']
   ) {
     console.log('Not a renovate branch, skipping')

--- a/packages/changesets-renovate/src/index.ts
+++ b/packages/changesets-renovate/src/index.ts
@@ -97,7 +97,10 @@ export async function run() {
 
   console.log('Detected branch:', branch)
 
-  if (!branch.current.startsWith('renovate/')) {
+  if (
+    !branch.current.startsWith('renovate/') &&
+    !process.env['SKIP_BRANCH_CHECK']
+  ) {
     console.log('Not a renovate branch, skipping')
 
     return


### PR DESCRIPTION
Hello,

I've added an option to disable the verification that it's running in a renovate branch `SKIP_BRANCH_CHECK`. This helps with projects that may have a custom branch name for renovate (#1706) or if you are using GitLab CI where you are in a detached HEAD state.