### PR TITLE
feat(changesets-renovate): filter out private packages

### DIFF
--- a/.changeset/clean-tigers-stalk.md
+++ b/.changeset/clean-tigers-stalk.md
@@ -1,0 +1,5 @@
+---
+"@scaleway/changesets-renovate": minor
+---
+
+filter out private packages from being published

--- a/packages/changesets-renovate/src/index.ts
+++ b/packages/changesets-renovate/src/index.ts
@@ -37,10 +37,9 @@ async function getPackagesNames(files: string[]): Promise<string[]> {
       name: string
       workspaces?: string[]
       version?: string
-      private?: boolean  // Add this type definition
+      private?: boolean
     }
 
-    // Skip if the package is private
     if (data.private) {
       return
     }

--- a/packages/changesets-renovate/src/index.ts
+++ b/packages/changesets-renovate/src/index.ts
@@ -37,6 +37,12 @@ async function getPackagesNames(files: string[]): Promise<string[]> {
       name: string
       workspaces?: string[]
       version?: string
+      private?: boolean  // Add this type definition
+    }
+
+    // Skip if the package is private
+    if (data.private) {
+      return
     }
 
     if (shouldIgnorePackage(data.name, ignoredPackages)) {
@@ -53,6 +59,7 @@ async function getPackagesNames(files: string[]): Promise<string[]> {
 
   return packages
 }
+
 
 async function createChangeset(
   fileName: string,


### PR DESCRIPTION
In a monorepo, people may choose to have some packages published, and keep other packages private.

Private packages (which are represented with a `private: true` key) ideally shouldn't be published. An example below:

```json
{
  "name": "@scope/package-name",
  "version": "0.0.0",
  "private": true,
  "description": "An internal package for providing a shared configuration to apps",
  "main": "./index.js",
}
```

[In the original GitHub Action from Backstage this is based off](https://github.com/backstage/backstage/blob/master/.github/workflows/sync_renovate-changesets.yml), the code is in fact filtering out private packages:

```typescript
// Parses package.json files and returns the package names
async function getPackagesNames(files) {
  const names = [];
  for (const file of files) {
    const data = JSON.parse(await fs.readFile(file, "utf8"));
    if (!data.private) { // ← It only grabs the package if it's not private.
      names.push(data.name);
    }
  }
  return names;
}
```

Would love to see that functionality represented in this package as well.