### PR TITLE
chore(changesets-renovate): add package support metadata

### DIFF
--- a/.changeset/small-tables-walk.md
+++ b/.changeset/small-tables-walk.md
@@ -1,0 +1,5 @@
+---
+"@scaleway/changesets-renovate": patch
+---
+
+chore(changesets-renovate): add package support metadata

--- a/packages/changesets-renovate/package.json
+++ b/packages/changesets-renovate/package.json
@@ -15,6 +15,10 @@
     "url": "git+https://github.com/scaleway/scaleway-lib.git",
     "directory": "packages/changesets-renovate"
   },
+  "bugs": {
+    "url": "https://github.com/scaleway/scaleway-lib/issues"
+  },
+  "homepage": "https://github.com/scaleway/scaleway-lib/tree/main/packages/changesets-renovate#readme",
   "bin": {
     "changesets-renovate": "dist/cli.mjs"
   },


### PR DESCRIPTION
## Summary

- add `bugs` metadata for the repository issue tracker
- add a package-specific `homepage` link for `@scaleway/changesets-renovate`

## Verification

- `node -e "const p=require('./packages/changesets-renovate/package.json'); if (p.bugs?.url !== 'https://github.com/scaleway/scaleway-lib/issues' || p.homepage !== 'https://github.com/scaleway/scaleway-lib/tree/main/packages/changesets-renovate#readme') process.exit(1); console.log(JSON.stringify({name:p.name, version:p.version, bugs:p.bugs, homepage:p.homepage}, null, 2))"`
- `npm pack ./packages/changesets-renovate --dry-run --ignore-scripts --json`
- `git diff --check`

This is an AI-assisted package metadata cleanup.
