### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/changesets-renovate/package.json
+++ b/packages/changesets-renovate/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@scaleway/changesets-renovate",
   "version": "3.0.3",
+  "bugs": {
+    "url": "https://github.com/scaleway/scaleway-lib/issues"
+  },
   "description": "Automatically create changesets for Renovate and pnpm catalogs",
   "keywords": [
     "catalogs",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/changesets-renovate/package.json`.