### PR TITLE
fix: use infinite dataloader stale page

### DIFF
--- a/.changeset/violet-dancers-create.md
+++ b/.changeset/violet-dancers-create.md
@@ -1,0 +1,5 @@
+---
+"@scaleway/use-dataloader": minor
+---
+
+Fix: Stale page when base query key change

--- a/packages/use-dataloader/src/__tests__/useInfiniteDataLoader.test.tsx
+++ b/packages/use-dataloader/src/__tests__/useInfiniteDataLoader.test.tsx
@@ -56,6 +56,11 @@ const getPrerequisite = (key: string) => {
   }
 }
 const wrapper = ({ children }: { children?: ReactNode }) => <DataLoaderProvider>{children}</DataLoaderProvider>
+const wrapperWithLifetime =
+  (lifetime: number) =>
+  ({ children }: { children?: ReactNode }) => (
+    <DataLoaderProvider defaultDatalifetime={lifetime}>{children}</DataLoaderProvider>
+  )
 
 describe('useInfinitDataLoader', () => {
   it('should get the first page on mount while enabled', async () => {
@@ -297,47 +302,587 @@ describe('useInfinitDataLoader', () => {
       },
     )
 
-    // Initially, isLoading should be true (first load with no cache)
     expect(result.current.isLoading).toBeTruthy()
     expect(result.current.isFetching).toBeTruthy()
     expect(result.current.data).toBeUndefined()
 
-    // Resolve the first request
     setCanResolve(true)
     await waitFor(() => {
       expect(result.current.isSuccess).toBeTruthy()
     })
 
-    // After first load, isLoading should be false but isFetching should also be false
     expect(result.current.isLoading).toBeFalsy()
     expect(result.current.isFetching).toBeFalsy()
     expect(result.current.data).toStrictEqual([{ data: 'Page 1 data', nextPage: 2 }])
 
-    // Trigger a loadMore
     setCanResolve(false)
     act(() => {
       result.current.loadMore()
     })
 
-    // During loadMore, isLoading should be false (we have cached data) but isFetching should be true
     await waitFor(() => {
       expect(result.current.isFetching).toBeTruthy()
     })
     expect(result.current.isLoading).toBeFalsy()
-    expect(result.current.data).toStrictEqual([{ data: 'Page 1 data', nextPage: 2 }]) // Still have cached data
+    expect(result.current.data).toStrictEqual([{ data: 'Page 1 data', nextPage: 2 }])
 
-    // Resolve the loadMore
     setCanResolve(true)
     await waitFor(() => {
       expect(result.current.isSuccess).toBeTruthy()
     })
 
-    // After loadMore, both should be false again
     expect(result.current.isLoading).toBeFalsy()
     expect(result.current.isFetching).toBeFalsy()
     expect(result.current.data).toStrictEqual([
       { data: 'Page 1 data', nextPage: 2 },
       { data: 'Page 2 data', nextPage: 3 },
     ])
+  })
+
+  it('should call onError callback when request fails', async () => {
+    const onErrorMock = vi.fn()
+    const { initialProps } = getPrerequisite('test-error')
+    const localConfig = {
+      ...config,
+      onError: onErrorMock,
+    }
+
+    const failingMethod = vi.fn(async () => {
+      throw new Error('Network error')
+    })
+
+    const localInitialProps = {
+      ...initialProps,
+      method: failingMethod,
+    }
+
+    const { result } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', localConfig),
+      {
+        initialProps: localInitialProps,
+        wrapper,
+      },
+    )
+
+    await waitFor(
+      () => {
+        expect(result.current.isError).toBeTruthy()
+      },
+      { timeout: 2000 },
+    )
+
+    expect(onErrorMock).toHaveBeenCalled()
+  })
+
+  it('should call onSuccess callback when request succeeds', async () => {
+    const onSuccessMock = vi.fn()
+    const { setCanResolve, initialProps } = getPrerequisite('test-success')
+    const localConfig = {
+      ...config,
+      onSuccess: onSuccessMock,
+    }
+
+    const { result } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', localConfig),
+      {
+        initialProps,
+        wrapper,
+      },
+    )
+
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(onSuccessMock).toHaveBeenCalledWith({ data: 'Page 1 data', nextPage: 2 })
+  })
+
+  it('should use initialData when provided', async () => {
+    const { setCanResolve, initialProps } = getPrerequisite('test-initial-data')
+    const localInitialProps = {
+      ...initialProps,
+      config: {
+        ...config,
+        initialData: [{ data: 'Initial data', nextPage: 1 }],
+      },
+    }
+
+    const { result } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', props.config),
+      {
+        initialProps: localInitialProps,
+        wrapper,
+      },
+    )
+
+    expect(result.current.data).toStrictEqual([{ data: 'Initial data', nextPage: 1 }])
+    expect(result.current.isLoading).toBeFalsy()
+
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.data).toStrictEqual([{ data: 'Page 1 data', nextPage: 2 }])
+  })
+
+  it('should return hasNextPage false when getNextPage returns undefined', async () => {
+    const noNextPageConfig: UseInfiniteDataLoaderConfig<
+      { nextPage: number | undefined; data: string },
+      Error,
+      { page: number | undefined },
+      'page'
+    > = {
+      enabled: true,
+      getNextPage: () => undefined,
+    }
+
+    const { setCanResolve, initialProps } = getPrerequisite('test-no-next-page')
+    const localMethod = vi.fn(
+      async () =>
+        new Promise<{ nextPage: number | undefined; data: string }>(resolve => {
+          resolve({ data: 'Last page', nextPage: undefined })
+        }),
+    )
+
+    const localInitialProps = {
+      ...initialProps,
+      method: localMethod,
+    }
+
+    const { result } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', noNextPageConfig),
+      {
+        initialProps: localInitialProps,
+        wrapper,
+      },
+    )
+
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.hasNextPage).toBeFalsy()
+    expect(result.current.data).toStrictEqual([{ data: 'Last page', nextPage: undefined }])
+  })
+
+  it('should reset page when baseKey changes', async () => {
+    const { setCanResolve, initialProps } = getPrerequisite('test-key-change')
+
+    const { result, rerender } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', config),
+      {
+        initialProps,
+        wrapper,
+      },
+    )
+
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    act(() => {
+      result.current.loadMore()
+    })
+    await waitFor(() => {
+      expect(result.current.isFetching).toBeTruthy()
+    })
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.data).toHaveLength(2)
+
+    const newInitialProps = {
+      ...initialProps,
+      key: 'test-key-change-new',
+      baseParams: { page: 1 },
+    }
+
+    rerender(newInitialProps)
+
+    // Page should be reset
+    await waitFor(() => {
+      expect(result.current.isFetching).toBeTruthy()
+    })
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.data).toHaveLength(1)
+  })
+
+  it('should set isIdle when enabled is false', async () => {
+    const { initialProps } = getPrerequisite('test-idle')
+    const localInitialProps = {
+      ...initialProps,
+      config: {
+        ...config,
+        enabled: false,
+      },
+    }
+
+    const { result } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', props.config),
+      {
+        initialProps: localInitialProps,
+        wrapper,
+      },
+    )
+
+    expect(result.current.isIdle).toBeTruthy()
+    expect(result.current.isLoading).toBeFalsy()
+    expect(result.current.isFetching).toBeFalsy()
+    expect(initialProps.method).not.toHaveBeenCalled()
+  })
+
+  it('should handle multiple loadMore calls in sequence', async () => {
+    const { setCanResolve, initialProps } = getPrerequisite('test-multiple-load-more')
+
+    const { result } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', config),
+      {
+        initialProps,
+        wrapper,
+      },
+    )
+
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    // Load multiple pages
+    setCanResolve(false)
+    act(() => {
+      result.current.loadMore()
+    })
+    await waitFor(() => {
+      expect(result.current.isFetching).toBeTruthy()
+    })
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    setCanResolve(false)
+    act(() => {
+      result.current.loadMore()
+    })
+    await waitFor(() => {
+      expect(result.current.isFetching).toBeTruthy()
+    })
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.data).toHaveLength(3)
+    expect(result.current.data?.[0]).toEqual({ data: 'Page 1 data', nextPage: 2 })
+    expect(result.current.data?.[1]).toEqual({ data: 'Page 2 data', nextPage: 3 })
+    expect(result.current.data?.[2]).toEqual({ data: 'Page 3 data', nextPage: 4 })
+  })
+
+  it('should handle reload after error', async () => {
+    const { setCanResolve, initialProps, resetCounter } = getPrerequisite('test-reload-error')
+
+    const { result } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', config),
+      {
+        initialProps,
+        wrapper,
+      },
+    )
+
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.data).toStrictEqual([{ data: 'Page 1 data', nextPage: 2 }])
+
+    resetCounter()
+    setCanResolve(false)
+    act(() => {
+      result.current.reload().catch(() => {})
+    })
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBeTruthy()
+    })
+
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.data).toStrictEqual([{ data: 'Page 1 data', nextPage: 2 }])
+  })
+
+  it('should use keepPreviousData option', async () => {
+    const { setCanResolve, initialProps } = getPrerequisite('test-keep-previous')
+    const localConfig = {
+      ...config,
+      keepPreviousData: true,
+    }
+
+    const { result } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', localConfig),
+      {
+        initialProps,
+        wrapper,
+      },
+    )
+
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    const firstData = result.current.data
+
+    setCanResolve(false)
+    act(() => {
+      result.current.loadMore()
+    })
+
+    expect(result.current.data).toEqual(firstData)
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBeTruthy()
+    })
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.data).toHaveLength(2)
+  })
+
+  it('should handle stale page scenario when baseKey changes', async () => {
+    const { setCanResolve, initialProps, resetCounter } = getPrerequisite('test-stale-page')
+
+    const { result, rerender } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', config),
+      {
+        initialProps,
+        wrapper,
+      },
+    )
+
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.data).toStrictEqual([{ data: 'Page 1 data', nextPage: 2 }])
+    expect(result.current.hasNextPage).toBeTruthy()
+
+    setCanResolve(false)
+    act(() => {
+      result.current.loadMore()
+    })
+    await waitFor(() => {
+      expect(result.current.isFetching).toBeTruthy()
+    })
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.data).toHaveLength(2)
+    expect(result.current.hasNextPage).toBeTruthy()
+
+    resetCounter()
+
+    const newInitialProps = {
+      ...initialProps,
+      key: 'test-stale-page-new-key',
+      baseParams: { page: 1 },
+    }
+
+    rerender(newInitialProps)
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBeTruthy()
+    })
+
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.isLoading).toBeTruthy()
+
+    // Resolve the new first page
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    // Should only have one page (the new first page)
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data?.[0]).toEqual({ data: 'Page 1 data', nextPage: 2 })
+  })
+
+  it('should restore nextPageRef on remount and allow loadMore', async () => {
+    const { setCanResolve, initialProps, resetCounter } = getPrerequisite('test-remount-load-more')
+
+    // First mount - load page 1 then loadMore page 2
+    const { result, unmount } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', config),
+      {
+        initialProps,
+        wrapper,
+      },
+    )
+
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    setCanResolve(false)
+    act(() => {
+      result.current.loadMore()
+    })
+    await waitFor(() => {
+      expect(result.current.isFetching).toBeTruthy()
+    })
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.data).toHaveLength(2)
+    expect(result.current.hasNextPage).toBeTruthy()
+
+    // Unmount the hook (simulates navigating away)
+    unmount()
+
+    // Reset counter to simulate fresh data for the remount
+    resetCounter()
+
+    // Second mount - should restore nextPageRef from cached data
+    const { result: result2 } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', config),
+      {
+        initialProps,
+        wrapper,
+      },
+    )
+
+    // Should have cached data restored
+    await waitFor(() => {
+      expect(result2.current.isSuccess).toBeTruthy()
+    })
+
+    // nextPageRef should be restored - hasNextPage should be true
+    expect(result2.current.hasNextPage).toBeTruthy()
+
+    // loadMore should work - it should trigger a new method call
+    const callsBeforeLoadMore = initialProps.method.mock.calls.length
+    setCanResolve(false)
+    act(() => {
+      result2.current.loadMore()
+    })
+    await waitFor(() => {
+      expect(result2.current.isFetching).toBeTruthy()
+    })
+
+    // Should have made one more call (for the next page)
+    expect(initialProps.method.mock.calls.length).toBe(callsBeforeLoadMore + 1)
+  })
+
+  it('should restore nextPage from cached data on remount without reload when data is fresh', async () => {
+    const { setCanResolve, initialProps } = getPrerequisite('test-remount-fresh-cache')
+    const wrapperFresh = wrapperWithLifetime(10_000)
+
+    const { result, unmount } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', config),
+      {
+        initialProps,
+        wrapper: wrapperFresh,
+      },
+    )
+
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    act(() => {
+      result.current.loadMore()
+    })
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(2)
+    })
+
+    expect(result.current.hasNextPage).toBeTruthy()
+
+    unmount()
+
+    // Remount with fresh cache (within 10s lifetime) - nextPage should be restored from cached data
+    const { result: result2 } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', config),
+      {
+        initialProps,
+        wrapper: wrapperFresh,
+      },
+    )
+
+    await waitFor(() => {
+      expect(result2.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result2.current.hasNextPage).toBeTruthy()
+
+    // loadMore should trigger exactly one new method call for the next page
+    const callsBeforeLoadMore = initialProps.method.mock.calls.length
+    act(() => {
+      result2.current.loadMore()
+    })
+    await waitFor(() => {
+      expect(result2.current.isFetching).toBeTruthy()
+    })
+
+    expect(initialProps.method.mock.calls.length).toBe(callsBeforeLoadMore + 1)
+  })
+
+  it('should keep hasNextPage accurate after remount with fresh cache (no stale useMemo)', async () => {
+    const { setCanResolve, initialProps } = getPrerequisite('test-remount-hasNextPage-accurate')
+    const wrapperFresh = wrapperWithLifetime(10_000)
+
+    const { result, unmount } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', config),
+      {
+        initialProps,
+        wrapper: wrapperFresh,
+      },
+    )
+
+    setCanResolve(true)
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.hasNextPage).toBeTruthy()
+    unmount()
+
+    const { result: result2 } = renderHook(
+      props => useInfiniteDataLoader(props.key, props.method, props.baseParams, 'page', config),
+      {
+        initialProps,
+        wrapper: wrapperFresh,
+      },
+    )
+
+    await waitFor(() => {
+      expect(result2.current.isSuccess).toBeTruthy()
+    })
+
+    // hasNextPage must be true (not stale false from useMemo)
+    expect(result2.current.hasNextPage).toBeTruthy()
   })
 })

--- a/packages/use-dataloader/src/useInfiniteDataLoader.ts
+++ b/packages/use-dataloader/src/useInfiniteDataLoader.ts
@@ -37,20 +37,18 @@ export const useInfiniteDataLoader = <
   const computedDatalifetime = dataLifetime ?? defaultDatalifetime
   const requestRefs = useRef<DataLoader<ResultType, ErrorType>[]>([])
   const [page, setPage] = useState(baseParams[pageParamKey])
-  const nextPageRef = useRef<typeof page | undefined>(page)
-
-  const getNextPageFnRef = useRef((...params: Parameters<NonNullable<typeof getNextPage>>) =>
-    getNextPage ? getNextPage(...params) : undefined,
-  )
-
+  const [nextPage, setNextPage] = useState<typeof page | undefined>(page)
+  const loadMoreBaseKeyRef = useRef<string | undefined>(undefined)
+  const baseQueryKey = useMemo(() => marshalQueryKey(baseKey), [baseKey])
+  const lastSyncedBaseKeyRef = useRef<string>(baseQueryKey)
+  const isPageStale = lastSyncedBaseKeyRef.current !== baseQueryKey
   const paramsArgs = {
     ...baseParams,
-    [pageParamKey]: page,
+    [pageParamKey]: isPageStale ? baseParams[pageParamKey] : page,
   }
 
   const getMethodRef = useRef(async () => method(paramsArgs))
   const getOnSuccessRef = useRef(async (...params: Parameters<NonNullable<typeof onSuccess>>) => onSuccess?.(...params))
-
   const getOnErrorRef = useRef(async (err: ErrorType) => onError?.(err) ?? onGlobalError?.(err))
 
   const [, setCounter] = useState(0)
@@ -58,8 +56,6 @@ export const useInfiniteDataLoader = <
   const forceRerender = useRef(() => {
     setCounter(current => current + 1)
   })
-
-  const baseQueryKey = useMemo(() => marshalQueryKey(baseKey), [baseKey])
 
   useEffect(() => {
     const notifyFn = forceRerender.current
@@ -80,10 +76,20 @@ export const useInfiniteDataLoader = <
   }, [])
 
   const getCurrentRequest = () => {
-    const currentQueryKey = marshalQueryKey([baseQueryKey, 'infinite', page as string | number])
+    const effectivePage = isPageStale ? baseParams[pageParamKey] : page
+    const currentQueryKey = marshalQueryKey([baseQueryKey, 'infinite', effectivePage as string | number])
 
     // Clean bad requests in the array
     requestRefs.current = requestRefs.current.filter(request => {
+      if (isPageStale) {
+        const initialPageKey = marshalQueryKey([baseQueryKey, 'infinite', baseParams[pageParamKey] as string | number])
+        if (request.key.endsWith(initialPageKey)) {
+          return true
+        }
+        request.removeObserver(forceRerender.current)
+        return false
+      }
+
       if (request.key.startsWith(computeKey(baseQueryKey))) {
         return true
       }
@@ -114,6 +120,14 @@ export const useInfiniteDataLoader = <
 
   const request = getCurrentRequest()
 
+  // Compute nextPage from current request.data during render to avoid stale closures
+  if (request.data) {
+    const computedNextPage = getNextPage ? getNextPage(request.data, paramsArgs) : undefined
+    if (computedNextPage !== nextPage) {
+      setNextPage(computedNextPage)
+    }
+  }
+
   const needLoad = useMemo(
     () =>
       !!(
@@ -125,23 +139,26 @@ export const useInfiniteDataLoader = <
   )
 
   const optimisticIsLoadingRef = useRef(needLoad)
-
   const previousDataRef = useRef(request.data)
 
   // isFetching is true when there is an active request in progress
   const isFetching = requestRefs.current.some(
     req => req.status === StatusEnum.LOADING || optimisticIsLoadingRef.current,
   )
-
   // Current request is loading and its the first request added in the refs
   const isLoadingFirstPage =
     (request.status === StatusEnum.LOADING || optimisticIsLoadingRef.current) && requestRefs.current.length <= 1
-
   const isSuccess = request.status === StatusEnum.SUCCESS
-
   const isError = request.status === StatusEnum.ERROR
-
   const isIdle = requestRefs.current.every(req => req.status === StatusEnum.IDLE && !enabled)
+  const computedData =
+    isLoadingFirstPage || [...requestRefs.current].filter(dataloader => !!dataloader.data).length === 0
+      ? initialData
+      : [...requestRefs.current]
+          .map(dataloader => dataloader.data)
+          .filter((data): data is NonNullable<typeof data> => !!data)
+  // isLoading is true only when there is no cache data and we're fetching data for the first time
+  const isLoading = !computedData && request.isFirstLoading && request.status === StatusEnum.LOADING
 
   const reload = useCallback(async () => {
     await Promise.all(
@@ -149,11 +166,17 @@ export const useInfiniteDataLoader = <
     )
   }, [])
 
-  const loadMoreRef = useRef(() => {
-    if (nextPageRef.current) {
-      setPage(curr => nextPageRef.current ?? curr)
+  const loadMore = useCallback(() => {
+    if (nextPage) {
+      loadMoreBaseKeyRef.current = baseQueryKey
+      setPage(() => {
+        if (loadMoreBaseKeyRef.current !== baseQueryKey) {
+          return baseParams[pageParamKey]
+        }
+        return nextPage
+      })
     }
-  })
+  }, [nextPage, baseQueryKey, baseParams, pageParamKey])
 
   useEffect(() => {
     request.method = async () => method(paramsArgs)
@@ -168,8 +191,11 @@ export const useInfiniteDataLoader = <
 
   // Reset page when baseParams or pageParamKey change
   useEffect(() => {
+    if (lastSyncedBaseKeyRef.current === baseQueryKey) return
     setPage(() => baseParams[pageParamKey])
-    nextPageRef.current = baseParams[pageParamKey]
+    setNextPage(undefined)
+    loadMoreBaseKeyRef.current = undefined
+    lastSyncedBaseKeyRef.current = baseQueryKey
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [baseQueryKey])
 
@@ -177,16 +203,9 @@ export const useInfiniteDataLoader = <
     if (needLoad) {
       const onSuccessLoad = getOnSuccessRef.current
       const onFailedLoad = getOnErrorRef.current
-      request
-        .load()
-        .then(async result => {
-          nextPageRef.current = getNextPageFnRef.current(result, paramsArgs) as typeof page
-          await onSuccessLoad(result)
-        })
-        .catch(onFailedLoad)
+      request.load().then(onSuccessLoad).catch(onFailedLoad)
     }
     optimisticIsLoadingRef.current = false
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [needLoad, request])
 
   useEffect(() => {
@@ -197,35 +216,33 @@ export const useInfiniteDataLoader = <
     getOnErrorRef.current = async err => onError?.(err) ?? onGlobalError?.(err)
   }, [onError, onGlobalError])
 
-  useEffect(() => {
-    getNextPageFnRef.current = (...params) => (getNextPage ? getNextPage(...params) : undefined)
-  }, [getNextPage])
-
-  const computedData =
-    isLoadingFirstPage || [...requestRefs.current].filter(dataloader => !!dataloader.data).length === 0
-      ? initialData
-      : ([...requestRefs.current]
-          .filter(dataloader => !!dataloader.data)
-          .map(dataloader => dataloader.data) as ResultType[])
-
-  // isLoading is true only when there is no cache data and we're fetching data for the first time
-  const isLoading = !computedData && request.isFirstLoading && request.status === StatusEnum.LOADING
-
   const data = useMemo<UseInfiniteDataLoaderResult<ResultType, ErrorType>>(
     () => ({
       data: computedData,
       error: request.error,
-      hasNextPage: nextPageRef.current !== undefined,
+      hasNextPage: nextPage !== undefined,
       isError,
       isFetching,
       isIdle,
       isLoading,
       isLoadingFirstPage,
       isSuccess,
-      loadMore: loadMoreRef.current,
+      loadMore,
       reload,
     }),
-    [computedData, isIdle, isLoading, isFetching, isSuccess, isError, request.error, isLoadingFirstPage, reload],
+    [
+      computedData,
+      isIdle,
+      isLoading,
+      isFetching,
+      isSuccess,
+      isError,
+      request.error,
+      isLoadingFirstPage,
+      reload,
+      nextPage,
+      loadMore,
+    ],
   )
 
   return data


### PR DESCRIPTION
## Issue

- Actually when you fetch multiple base with a hook then change a subcomponent and you baseParams the query will fetch the first page but not clean the nextPageToken so I will duplicate the result or lead to an error

## What did I do
- Ensure the baseQueryKey still the same or reset page and nextPageRef