### PR TITLE
fix(scouter): use regular deps instead of peer deps

### DIFF
--- a/packages/scouter/package.json
+++ b/packages/scouter/package.json
@@ -31,21 +31,20 @@
     "test:unit": "vitest --run",
     "test:unit:coverage": "pnpm test:unit --coverage"
   },
+  "dependencies": {
+    "history": "catalog:",
+    "query-string": "catalog:",
+    "regexparam": "catalog:"
+  },
   "devDependencies": {
     "@scaleway/sdk-client": "catalog:",
     "@types/react": "catalog:",
-    "history": "catalog:",
-    "query-string": "catalog:",
     "react": "catalog:",
-    "regexparam": "catalog:",
     "zod": "catalog:"
   },
   "peerDependencies": {
     "@scaleway/sdk-client": "^2.4.0",
-    "history": "^5.3.0",
-    "query-string": "^7.1.1",
     "react": "18.x || 19.x",
-    "regexparam": "3.x",
     "zod": "4.x"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,16 @@ importers:
   packages/regex: {}
 
   packages/scouter:
+    dependencies:
+      history:
+        specifier: 'catalog:'
+        version: 5.3.0
+      query-string:
+        specifier: 'catalog:'
+        version: 7.1.1
+      regexparam:
+        specifier: 'catalog:'
+        version: 3.0.0
     devDependencies:
       '@scaleway/sdk-client':
         specifier: 'catalog:'
@@ -360,18 +370,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
-      history:
-        specifier: 'catalog:'
-        version: 5.3.0
-      query-string:
-        specifier: 'catalog:'
-        version: 7.1.1
       react:
         specifier: 'catalog:'
         version: 19.2.7
-      regexparam:
-        specifier: 'catalog:'
-        version: 3.0.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3


### PR DESCRIPTION
Move "history", "query-string" and "regexparam" to regular deps instead of peerDeps.