### PR TITLE
fix(scouter): use context instead of useSyncExternalStore

### DIFF
--- a/.changeset/open-bars-stand.md
+++ b/.changeset/open-bars-stand.md
@@ -1,0 +1,5 @@
+---
+"@scaleway/scouter": patch
+---
+
+Batch history changes by using state+context instead of useSyncExternalStore

--- a/packages/scouter/src/Router.tsx
+++ b/packages/scouter/src/Router.tsx
@@ -1,7 +1,8 @@
 import type { History } from 'history'
 import type { PropsWithChildren } from 'react'
-import { useMemo } from 'react'
+import { useLayoutEffect, useMemo, useState } from 'react'
 import { HistoryContext } from './useHistory'
+import { LocationContext } from './useLocation'
 import type { RouteContextValue } from './useRouteContext'
 import { RouteContext } from './useRouteContext'
 
@@ -13,9 +14,23 @@ export const Router = ({ history, children }: PropsWithChildren<{ history: Histo
     [],
   )
 
+  const [location, setLocation] = useState(() => history.location)
+
+  useLayoutEffect(() => {
+    const unlisten = history.listen(() => {
+      setLocation(history.location)
+    })
+    // Sync in case a navigation happened before the listener was registered
+    // (e.g., a <Redirect> firing in a child's useLayoutEffect during mount).
+    setLocation(history.location)
+    return unlisten
+  }, [history])
+
   return (
     <HistoryContext.Provider value={history}>
-      <RouteContext.Provider value={rootRouteValue}>{children}</RouteContext.Provider>
+      <LocationContext.Provider value={location}>
+        <RouteContext.Provider value={rootRouteValue}>{children}</RouteContext.Provider>
+      </LocationContext.Provider>
     </HistoryContext.Provider>
   )
 }

--- a/packages/scouter/src/__tests__/integration.test.tsx
+++ b/packages/scouter/src/__tests__/integration.test.tsx
@@ -2,8 +2,9 @@
 import '@testing-library/jest-dom'
 import { act, render, screen } from '@testing-library/react'
 import { createMemoryHistory as createHistory } from 'history'
+import { useEffect, useState } from 'react'
 import { describe, expect, it, test } from 'vitest'
-import { MemoryRouter, Redirect, Route, Switch, useLocation } from '../index'
+import { MemoryRouter, Redirect, Route, Switch, useLocation, useNavigate } from '../index'
 import { Router } from '../Router'
 
 test('renders routes correctly', () => {
@@ -119,4 +120,105 @@ test('location changes trigger re-renders', () => {
   })
 
   expect(renderCount).toBeGreaterThan(countAfterInitial)
+})
+
+test('batches multiple navigations in a microtask (no intermediate render)', async () => {
+  const history = createHistory({ initialEntries: ['/start'] })
+
+  const seenLocations: string[] = []
+
+  function Tracker() {
+    const location = useLocation()
+    seenLocations.push(location.pathname)
+    return <div>{location.pathname}</div>
+  }
+
+  function App() {
+    const navigate = useNavigate()
+    const [count, setCount] = useState(0)
+
+    useEffect(() => {
+      if (count === 0) {
+        // Simulate the real-world scenario: navigate + setState inside a
+        // microtask (Promise continuation). With useSyncExternalStore the
+        // first navigate would trigger a synchronous re-render before
+        // setCount runs, causing the component to see '/intermediate'.
+        Promise.resolve().then(() => {
+          navigate('/intermediate')
+          setCount(1)
+          navigate('/final')
+        })
+      }
+    }, [count, navigate])
+
+    return <Tracker />
+  }
+
+  render(
+    <Router history={history}>
+      <App />
+    </Router>,
+  )
+
+  expect(screen.getByText('/start')).toBeInTheDocument()
+
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  // Should see '/start' (initial) and '/final' (batched), but NOT '/intermediate'
+  expect(seenLocations).toContain('/start')
+  expect(seenLocations).toContain('/final')
+  expect(seenLocations).not.toContain('/intermediate')
+})
+
+test('does not unmount components during batched navigations', async () => {
+  const history = createHistory({ initialEntries: ['/start'] })
+
+  let unmountCount = 0
+
+  function Sticky() {
+    useEffect(() => {
+      return () => {
+        unmountCount++
+      }
+    }, [])
+    return <div>Sticky</div>
+  }
+
+  function App() {
+    const navigate = useNavigate()
+
+    useEffect(() => {
+      // Navigate to /intermediate (would unmount Sticky), then immediately
+      // back to /start (where Sticky lives). With batching, Sticky should
+      // never unmount because React only renders the final location.
+      Promise.resolve().then(() => {
+        navigate('/intermediate')
+        navigate('/start')
+      })
+    }, [navigate])
+
+    return (
+      <Switch>
+        <Route path="/intermediate" render={() => <div>Intermediate</div>} />
+        <Route render={() => <Sticky />} />
+      </Switch>
+    )
+  }
+
+  render(
+    <Router history={history}>
+      <App />
+    </Router>,
+  )
+
+  expect(screen.getByText('Sticky')).toBeInTheDocument()
+
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  expect(unmountCount).toBe(0)
+  expect(screen.getByText('Sticky')).toBeInTheDocument()
 })

--- a/packages/scouter/src/useLocation.ts
+++ b/packages/scouter/src/useLocation.ts
@@ -1,12 +1,12 @@
 import type { Location } from 'history'
-import { useSyncExternalStore } from 'react'
-import { useHistory } from './useHistory'
+import { createContext, useContext } from 'react'
+
+export const LocationContext = createContext<Location | null>(null)
 
 export function useLocation(): Location {
-  const history = useHistory()
-
-  return useSyncExternalStore<Location>(
-    onChange => history.listen(onChange),
-    () => history.location,
-  )
+  const location = useContext(LocationContext)
+  if (location === null) {
+    throw new Error('Missing RouterContext, make sure you are inside a Router')
+  }
+  return location
 }


### PR DESCRIPTION
Fix scouter: Batch history changes by using state+context instead of useSyncExternalStore