### PR TITLE
fix(changesets-renovate): discover workspace globs for catalog changesets

### DIFF
--- a/.changeset/fix-catalog-package-glob.md
+++ b/.changeset/fix-catalog-package-glob.md
@@ -1,0 +1,7 @@
+---
+'@scaleway/changesets-renovate': patch
+---
+
+Fix catalog changeset generation failing to identify affected workspace packages. `findAffectedPackages` now auto-discovers workspace package globs from `pnpm-workspace.yaml` (`packages` field) and the root `package.json` (`workspaces` field) instead of relying on a hardcoded `packages/*/package.json` default, which missed packages in non-default layouts (e.g. `apps/*`).
+
+Fixes https://github.com/scaleway/scaleway-lib/issues/3134

--- a/packages/changesets-renovate/src/__tests__/utils.test.ts
+++ b/packages/changesets-renovate/src/__tests__/utils.test.ts
@@ -6,6 +6,7 @@ import { parse } from 'yaml'
 import {
   findAffectedPackages,
   findChangedDependencies,
+  getWorkspacePackageGlobs,
   loadCatalogFromFile,
   loadCatalogFromWorkspaceContent,
 } from '../utils.js'
@@ -150,8 +151,117 @@ catalog:
     })
   })
 
+  describe('getWorkspacePackageGlobs', () => {
+    it('should discover globs from pnpm-workspace.yaml', async () => {
+      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
+        if (filePath === 'pnpm-workspace.yaml') {
+          return 'packages:\n  - packages/*\n  - apps/*'
+        }
+
+        const error = new Error('not found') as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }) as any)
+      vi.mocked(parse).mockReturnValue({ packages: ['packages/*', 'apps/*'] })
+
+      const result = await getWorkspacePackageGlobs()
+
+      expect(result).toStrictEqual(['packages/*/package.json', 'apps/*/package.json'])
+    })
+
+    it('should discover globs from root package.json workspaces', async () => {
+      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
+        if (filePath === 'package.json') {
+          return JSON.stringify({ workspaces: ['packages/*', 'tools/*'] })
+        }
+
+        const error = new Error('not found') as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }) as any)
+
+      const result = await getWorkspacePackageGlobs()
+
+      expect(result).toStrictEqual(['packages/*/package.json', 'tools/*/package.json'])
+    })
+
+    it('should support workspaces as { packages: [] } object', async () => {
+      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
+        if (filePath === 'package.json') {
+          return JSON.stringify({ workspaces: { packages: ['apps/*'] } })
+        }
+
+        const error = new Error('not found') as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }) as any)
+
+      const result = await getWorkspacePackageGlobs()
+
+      expect(result).toStrictEqual(['apps/*/package.json'])
+    })
+
+    it('should merge and deduplicate globs from both sources', async () => {
+      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
+        if (filePath === 'pnpm-workspace.yaml') {
+          return 'packages:\n  - packages/*'
+        }
+        if (filePath === 'package.json') {
+          return JSON.stringify({ workspaces: ['packages/*', 'apps/*'] })
+        }
+
+        return '{}'
+      }) as any)
+      vi.mocked(parse).mockReturnValue({ packages: ['packages/*'] })
+
+      const result = await getWorkspacePackageGlobs()
+
+      expect(result).toStrictEqual(['packages/*/package.json', 'apps/*/package.json'])
+    })
+
+    it('should fall back to empty array when no workspace config exists', async () => {
+      vi.mocked(readFile).mockImplementation((async () => {
+        const error = new Error('not found') as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }) as any)
+
+      const result = await getWorkspacePackageGlobs()
+
+      expect(result).toStrictEqual([])
+    })
+
+    it('should strip trailing slashes from workspace patterns', async () => {
+      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
+        if (filePath === 'pnpm-workspace.yaml') {
+          return 'packages:\n  - packages/*/'
+        }
+
+        const error = new Error('not found') as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }) as any)
+      vi.mocked(parse).mockReturnValue({ packages: ['packages/*/'] })
+
+      const result = await getWorkspacePackageGlobs()
+
+      expect(result).toStrictEqual(['packages/*/package.json'])
+    })
+  })
+
   describe('findAffectedPackages', () => {
     beforeEach(() => {
+      // Default workspace discovery returns the legacy default glob
+      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
+        if (filePath === 'pnpm-workspace.yaml') {
+          return 'packages:\n  - packages/*'
+        }
+
+        const error = new Error('not found') as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }) as any)
+      vi.mocked(parse).mockReturnValue({ packages: ['packages/*'] })
       vi.mocked(glob).mockResolvedValue([
         'packages/package-a/package.json',
         'packages/package-b/package.json',
@@ -186,7 +296,7 @@ catalog:
 
       const result = await findAffectedPackages(['changed-dep'])
 
-      expect(glob).toHaveBeenCalledWith('packages/*/package.json', { expandDirectories: false })
+      expect(glob).toHaveBeenCalledWith(['packages/*/package.json'], { expandDirectories: false })
       expect(result).toBeInstanceOf(Set)
       expect(result.size).toBe(1)
       expect(result).toContain('package-a')
@@ -222,7 +332,7 @@ catalog:
 
       const result = await findAffectedPackages(['changed-dep'])
 
-      expect(glob).toHaveBeenCalledWith('packages/*/package.json', { expandDirectories: false })
+      expect(glob).toHaveBeenCalledWith(['packages/*/package.json'], { expandDirectories: false })
       expect(result).toBeInstanceOf(Set)
       expect(result.size).toBe(1)
       expect(result).toContain('package-a')
@@ -267,7 +377,7 @@ catalog:
 
       const result = await findAffectedPackages(['changed-dep'])
 
-      expect(glob).toHaveBeenCalledWith('packages/*/package.json', { expandDirectories: false })
+      expect(glob).toHaveBeenCalledWith(['packages/*/package.json'], { expandDirectories: false })
       expect(result).toBeInstanceOf(Set)
       expect(result.size).toBe(1)
       expect(result).toContain('package-a')
@@ -306,6 +416,68 @@ catalog:
       const result = await findAffectedPackages(['changed-dep'])
 
       expect(result).toBeInstanceOf(Set)
+      expect(result.size).toBe(0)
+    })
+
+    it('should respect explicitly provided packageJsonGlobs over discovered ones', async () => {
+      vi.mocked(glob).mockResolvedValue(['apps/app-a/package.json'])
+      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
+        if (filePath === 'apps/app-a/package.json') {
+          return JSON.stringify({
+            dependencies: {
+              'changed-dep': 'catalog:',
+            },
+            version: '1.0.0',
+            name: 'app-a',
+          })
+        }
+
+        return '{}'
+      }) as any)
+
+      const result = await findAffectedPackages(['changed-dep'], ['apps/*/package.json'])
+
+      expect(glob).toHaveBeenCalledWith(['apps/*/package.json'], { expandDirectories: false })
+      expect(result.size).toBe(1)
+      expect(result).toContain('app-a')
+    })
+
+    it('should discover non-default workspace layouts (apps/*) from pnpm-workspace.yaml', async () => {
+      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
+        if (filePath === 'pnpm-workspace.yaml') {
+          return 'packages:\n  - apps/*'
+        }
+        if (filePath === 'apps/app-a/package.json') {
+          return JSON.stringify({
+            dependencies: {
+              'changed-dep': 'catalog:',
+            },
+            version: '1.0.0',
+            name: 'app-a',
+          })
+        }
+
+        const error = new Error('not found') as NodeJS.ErrnoException
+        error.code = 'ENOENT'
+        throw error
+      }) as any)
+      vi.mocked(parse).mockReturnValue({ packages: ['apps/*'] })
+      vi.mocked(glob).mockResolvedValue(['apps/app-a/package.json'])
+
+      const result = await findAffectedPackages(['changed-dep'])
+
+      expect(glob).toHaveBeenCalledWith(['apps/*/package.json'], { expandDirectories: false })
+      expect(result.size).toBe(1)
+      expect(result).toContain('app-a')
+    })
+
+    it('should fall back to packages/*/package.json when no workspace config is found', async () => {
+      vi.mocked(readFile).mockRejectedValue(new Error('File read error'))
+      vi.mocked(glob).mockResolvedValue(['packages/package-a/package.json'])
+
+      const result = await findAffectedPackages(['changed-dep'])
+
+      expect(glob).toHaveBeenCalledWith(['packages/*/package.json'], { expandDirectories: false })
       expect(result.size).toBe(0)
     })
   })

--- a/packages/changesets-renovate/src/utils.ts
+++ b/packages/changesets-renovate/src/utils.ts
@@ -4,6 +4,56 @@ import { read } from '@changesets/config'
 import { glob } from 'tinyglobby'
 import { parse } from 'yaml'
 
+/**
+ * Discover workspace package globs from pnpm-workspace.yaml (`packages` field)
+ * and/or the root package.json (`workspaces` field).
+ *
+ * Supports both npm/yarn workspaces (string or string[] or { packages: [] })
+ * and pnpm workspaces. Each returned glob is normalized to point at a
+ * package.json file (e.g. the glob `packages` with a star wildcard becomes
+ * `packages/<star>/package.json`).
+ *
+ * @returns Array of glob patterns pointing to package.json files. Falls back
+ * to the default `packages/<star>/package.json` pattern when no workspace
+ * config is found.
+ */
+export async function getWorkspacePackageGlobs(): Promise<string[]> {
+  const globs: string[] = []
+
+  // 1. pnpm-workspace.yaml `packages:` field
+  try {
+    const content = await readFile('pnpm-workspace.yaml', 'utf8')
+    const parsed = parse(content) as {
+      packages?: string[]
+    } | null
+
+    if (Array.isArray(parsed?.packages)) {
+      globs.push(...parsed.packages.map(pkg => `${pkg.replace(/\/$/u, '')}/package.json`))
+    }
+  } catch {
+    // pnpm-workspace.yaml may not exist (npm/yarn monorepo)
+  }
+
+  // 2. Root package.json `workspaces` field (npm/yarn)
+  try {
+    const content = await readFile('package.json', 'utf8')
+    const parsed = JSON.parse(content) as {
+      workspaces?: string[] | { packages?: string[] }
+    }
+
+    const workspaces = Array.isArray(parsed.workspaces) ? parsed.workspaces : parsed.workspaces?.packages
+
+    if (Array.isArray(workspaces)) {
+      globs.push(...workspaces.map(pkg => `${pkg.replace(/\/$/u, '')}/package.json`))
+    }
+  } catch {
+    // Root package.json may not exist or be unreadable
+  }
+
+  // Deduplicate while preserving order
+  return [...new Set(globs)]
+}
+
 function shouldSkipPackage(
   packageJson: { version?: string; name: string; private?: boolean },
   {
@@ -123,19 +173,23 @@ export function findChangedDependencies(
 /**
  * Find packages affected by dependency changes
  * @param changedDeps Array of changed dependency names
- * @param packageJsonGlob Glob pattern to find package.json files
+ * @param packageJsonGlobs Glob patterns to find package.json files. When
+ * omitted, workspace globs are auto-discovered from pnpm-workspace.yaml and
+ * the root package.json, falling back to the default `packages/<star>/package.json`.
  * @returns Set of package names that are affected by the changes
  */
-export async function findAffectedPackages(
-  changedDeps: string[],
-  packageJsonGlob = 'packages/*/package.json',
-): Promise<Set<string>> {
+export async function findAffectedPackages(changedDeps: string[], packageJsonGlobs?: string[]): Promise<Set<string>> {
   if (changedDeps.length === 0) {
     return new Set()
   }
 
+  const globs = packageJsonGlobs && packageJsonGlobs.length > 0 ? packageJsonGlobs : await getWorkspacePackageGlobs()
+
+  // Fall back to a sensible default if nothing was discovered
+  const patterns = globs.length > 0 ? globs : ['packages/*/package.json']
+
   const config = await getChangesetConfig()
-  const packageJsonPaths = await glob(packageJsonGlob, { expandDirectories: false })
+  const packageJsonPaths = await glob(patterns, { expandDirectories: false })
   const affectedPackages = new Set<string>()
 
   for (const pkgJsonPath of packageJsonPaths) {


### PR DESCRIPTION
## Problem

When Renovate updates a dependency in a pnpm workspace catalog (`pnpm-workspace.yaml`), `@scaleway/changesets-renovate` detected the catalog change but failed to identify the affected workspace packages, outputting:

```
📦 No packages affected by catalog changes.
```

The resulting changeset then incorrectly targeted the root monorepo package name instead of the actual workspace packages consuming the dependency via the `"catalog:"` protocol.

Fixes https://github.com/scaleway/scaleway-lib/issues/3134

## Root cause

`findAffectedPackages` in `packages/changesets-renovate/src/utils.ts` used a hardcoded default glob `packages/*/package.json`. For monorepos with a different layout (e.g. `apps/*`, nested directories, or multiple workspace roots), this glob matched nothing, so no affected packages were found.

## Fix

- Added `getWorkspacePackageGlobs()` which auto-discovers workspace package patterns from:
  - `pnpm-workspace.yaml` → `packages:` field (pnpm)
  - root `package.json` → `workspaces` field (npm/yarn, supports both `string[]` and `{ packages: [] }` shapes)
- Each pattern is normalized to point at `package.json` (e.g. `apps/*` → `apps/*/package.json`), trailing slashes are stripped, and results are deduplicated.
- `findAffectedPackages` now:
  1. Uses explicitly-provided globs if given
  2. Otherwise auto-discovers via `getWorkspacePackageGlobs()`
  3. Falls back to `packages/*/package.json` only when no workspace config is found
- `tinyglobby`'s `glob` now receives an **array** of patterns, so multi-root workspaces (`packages/*` + `apps/*`) are scanned in one pass.

## Tests

- Added a `getWorkspacePackageGlobs` suite (6 tests): pnpm discovery, npm/yarn discovery, object-shape workspaces, merge+dedup, fallback, trailing-slash stripping.
- Added `findAffectedPackages` tests for: explicit globs override discovery, `apps/*` layout from pnpm-workspace.yaml, and fallback when no workspace config exists.
- Updated existing tests to mock workspace config reads and assert against the array form `glob(['packages/*/package.json'], ...)`.

All 47 tests pass, typecheck clean, oxlint reports no new errors.