### PR TITLE
fix(use-dataloader): fix flaky test

### DIFF
--- a/packages/use-dataloader/src/__tests__/useDataLoader.test.tsx
+++ b/packages/use-dataloader/src/__tests__/useDataLoader.test.tsx
@@ -363,8 +363,8 @@ describe('useDataLoader', () => {
     expect(result.current.isFetching).toBeFalsy()
     await waitFor(() => {
       expect(result.current.isFetching).toBeTruthy()
+      expect(result.current.isSuccess).toBeFalsy()
     })
-    expect(result.current.isSuccess).toBeFalsy()
     await waitFor(() => {
       expect(result.current.isSuccess).toBeTruthy()
     })
@@ -382,10 +382,10 @@ describe('useDataLoader', () => {
     })
     await waitFor(() => {
       expect(result.current.isFetching).toBeTruthy()
+      expect(result.current.isSuccess).toBeFalsy()
     })
     expect(result.current.data).toBe(2)
     expect(result.current.isPolling).toBeTruthy()
-    expect(result.current.isSuccess).toBeFalsy()
     expect(method2).toHaveBeenCalledTimes(2)
     await waitFor(() => {
       expect(result.current.isSuccess).toBeTruthy()


### PR DESCRIPTION
### Problem

The test `useDataLoader > should render correctly with pooling` failed intermittently. The assertion `expect(result.current.isSuccess).toBeFalsy()` occasionally received `true` instead of `false`.

### Root cause

A race condition in the test, not a bug in the hook. The pooling interval is `1000ms`, but each request resolves after only `50ms` (`PROMISE_TIMEOUT`). The sequence is:

1. Poll fires → `status = LOADING` → `isFetching: true`, `isSuccess: false`
2. 50ms later → `status = SUCCESS` → `isSuccess: true`

The old test used `waitFor(() => expect(isFetching).toBeTruthy())` followed by a **separate** assertion for `isSuccess` to be falsy. Between `waitFor` resolving and the next line executing, the 50ms timer could fire and flip `isSuccess` back to `true`, causing the intermittent failure.

### Fix

Moved the `isSuccess` assertion into the same `waitFor` callback so both conditions are evaluated against the same snapshot atomically:

```ts
await waitFor(() => {
  expect(result.current.isFetching).toBeTruthy()
  expect(result.current.isSuccess).toBeFalsy()
})