### PR TITLE
chore: add pkg.pr.new continuous preview releases

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,20 @@
+name: Publish Preview
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm exec pkg-pr-new publish --pnpm './packages/*' --commentWithSha

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ AGENTS.md
 
 # dist compare migration
 .dist-compare
+.opencode/

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "oxlint-tsgolint": "catalog:",
+    "pkg-pr-new": "catalog:",
     "publint": "catalog:",
     "read-pkg": "catalog:",
     "tsdown": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,9 @@ catalogs:
     oxlint-tsgolint:
       specifier: 7.0.2001
       version: 7.0.2001
+    pkg-pr-new:
+      specifier: 0.0.88
+      version: 0.0.88
     publint:
       specifier: 0.3.24
       version: 0.3.24
@@ -462,6 +465,9 @@ importers:
       oxlint-tsgolint:
         specifier: 'catalog:'
         version: 7.0.2001
+      pkg-pr-new:
+        specifier: 'catalog:'
+        version: 0.0.88
       publint:
         specifier: 'catalog:'
         version: 0.3.24
@@ -2505,6 +2511,10 @@ packages:
     resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
 
+  pkg-pr-new@0.0.88:
+    resolution: {integrity: sha512-Xc6PMJ2gher0WZP+rtjefFk26hIb7V1PTLL30bmy1Z2vsRmSvqiss7Ag1XUdyplTGYzIlFNJp4L3vMNmK44N6g==}
+    hasBin: true
+
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4484,6 +4494,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.7: {}
+
+  pkg-pr-new@0.0.88: {}
 
   postcss@8.5.26:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,6 +61,7 @@ catalog:
   yaml: 2.9.0
   zod: 4.5.4
   '@testing-library/dom': 10.4.1
+  pkg-pr-new: 0.0.88
 catalogMode: strict
 cleanupUnusedCatalogs: true
 


### PR DESCRIPTION
Publishes preview releases for every commit and PR using [pkg.pr.new](https://pkg.pr.new).

## What
- Adds `pkg-pr-new` dev dependency
- Adds `.github/workflows/pkg-pr-new.yml` workflow that builds and publishes all packages in `packages/*` on every push (non-tag) and pull request

## Notes
- Uses `--pnpm` flag because the repo uses pnpm catalogs (`catalog:` protocol), which `npm pack` cannot resolve
- Uses `--commentWithSha` for commit-SHA-based preview URLs
- The [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) must be installed on this repository