### PR TITLE
fix(oxlint): fix vitest/no-conditional-in-test violations

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
       plugins: ['vitest'],
       rules: {
         'vitest/no-conditional-expect': 'warn',
-        'vitest/no-conditional-in-test': 'warn',
         'vitest/no-mocks-import': 'warn',
         'vitest/prefer-expect-type-of': 'warn',
         'vitest/prefer-import-in-mock': 'warn',

--- a/packages/changesets-renovate/src/__tests__/generate-changeset.test.ts
+++ b/packages/changesets-renovate/src/__tests__/generate-changeset.test.ts
@@ -1,4 +1,3 @@
-// oxlint-disable max-lines
 import { readFile, writeFile } from 'node:fs/promises'
 import { defaultConfig, readConfig } from '@changesets/config'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -19,6 +18,10 @@ vi.mock(import('@changesets/config'), async importOriginal => {
 
 const mockedWriteFile = vi.mocked(writeFile)
 const mockedReadFile = vi.mocked(readFile)
+
+const mockReadFileMap = (files: Record<string, string>) => {
+  mockedReadFile.mockImplementation((async (path: unknown) => files[path as string] ?? '{}') as never)
+}
 
 describe('generate changeset file', () => {
   beforeEach(() => {
@@ -84,12 +87,8 @@ describe('generate changeset file', () => {
     })
 
     // Mock changeset config for this test
-    mockedReadFile.mockImplementation(async path => {
-      if (path === 'test/package.json') {
-        return `{"name":"packageName","version":"1.0.0","dependencies": { "package": "1.0.0", "package2": "1.2.2" }}`
-      }
-
-      return '{}'
+    mockReadFileMap({
+      'test/package.json': `{"name":"packageName","version":"1.0.0","dependencies": { "package": "1.0.0", "package2": "1.2.2" }}`,
     })
 
     process.env['BRANCH_PREFIX'] = 'dep-upgrade/'
@@ -134,12 +133,8 @@ describe('generate changeset file', () => {
     })
 
     // Mock changeset config for this test
-    mockedReadFile.mockImplementation(async path => {
-      if (path === 'test/package.json') {
-        return `{"name":"packageName","version":"1.0.0","dependencies": { "package": "1.0.0", "package2": "1.2.2" }}`
-      }
-
-      return '{}'
+    mockReadFileMap({
+      'test/package.json': `{"name":"packageName","version":"1.0.0","dependencies": { "package": "1.0.0", "package2": "1.2.2" }}`,
     })
 
     process.env['SKIP_BRANCH_CHECK'] = 'TRUE'
@@ -222,12 +217,8 @@ describe('generate changeset file', () => {
     })
 
     // Mock changeset config for this test
-    mockedReadFile.mockImplementation(async path => {
-      if (path === 'test/package.json') {
-        return `{"name":"packageName","version":"1.0.0","dependencies": { "packagez": "1.0.0", "package2": "1.2.2" }}`
-      }
-
-      return '{}'
+    mockReadFileMap({
+      'test/package.json': `{"name":"packageName","version":"1.0.0","dependencies": { "packagez": "1.0.0", "package2": "1.2.2" }}`,
     })
 
     await run()
@@ -270,12 +261,8 @@ describe('generate changeset file', () => {
     })
 
     // Mock changeset config for this test
-    mockedReadFile.mockImplementation(async path => {
-      if (path === 'test/package.json') {
-        return `{"name":"packageName","version":"1.0.0","dependencies": { "package": "1.0.0", "package2": "1.2.2" }}`
-      }
-
-      return '{}'
+    mockReadFileMap({
+      'test/package.json': `{"name":"packageName","version":"1.0.0","dependencies": { "package": "1.0.0", "package2": "1.2.2" }}`,
     })
 
     process.env['SKIP_COMMIT'] = 'TRUE'
@@ -323,15 +310,9 @@ describe('generate changeset file', () => {
     })
 
     // Mock changeset config for this test
-    mockedReadFile.mockImplementation(async path => {
-      if (path === 'test-a/package.json') {
-        return `{"name":"packageNameA","version":"1.0.0","dependencies": { "packagez": "1.0.0" }}`
-      }
-      if (path === 'test-b/package.json') {
-        return `{"name":"packageNameB","version":"1.0.0","dependencies": { "packagea": "1.0.0" }}`
-      }
-
-      return '{}'
+    mockReadFileMap({
+      'test-a/package.json': `{"name":"packageNameA","version":"1.0.0","dependencies": { "packagez": "1.0.0" }}`,
+      'test-b/package.json': `{"name":"packageNameB","version":"1.0.0","dependencies": { "packagea": "1.0.0" }}`,
     })
 
     process.env['SKIP_COMMIT'] = 'TRUE'
@@ -368,12 +349,8 @@ describe('generate changeset file', () => {
     })
 
     // Mock changeset config for this test
-    mockedReadFile.mockImplementation(async path => {
-      if (path === 'package.json') {
-        return `{"name":"packageName","workspaces":[]}`
-      }
-
-      return '{}'
+    mockReadFileMap({
+      'package.json': `{"name":"packageName","workspaces":[]}`,
     })
 
     await run()
@@ -404,12 +381,8 @@ describe('generate changeset file', () => {
     })
 
     // Mock changeset config for this test
-    mockedReadFile.mockImplementation(async path => {
-      if (path === 'package.json') {
-        return `{"name":"packageName"}`
-      }
-
-      return '{}'
+    mockReadFileMap({
+      'package.json': `{"name":"packageName"}`,
     })
 
     await run()
@@ -446,12 +419,8 @@ describe('generate changeset file', () => {
     })
 
     // Mock changeset config for this test
-    mockedReadFile.mockImplementation(async path => {
-      if (path === 'test/package.json') {
-        return `{"name":"packageName","version":"1.0.0"}`
-      }
-
-      return '{}'
+    mockReadFileMap({
+      'test/package.json': `{"name":"packageName","version":"1.0.0"}`,
     })
 
     await run()
@@ -491,12 +460,8 @@ describe('generate changeset file', () => {
     })
 
     // Mock changeset config for this test
-    mockedReadFile.mockImplementation(async path => {
-      if (path === 'test/package.json') {
-        return `{"name":"packageName","version":"1.0.0", "private": true }`
-      }
-
-      return '{}'
+    mockReadFileMap({
+      'test/package.json': `{"name":"packageName","version":"1.0.0", "private": true }`,
     })
 
     await run()

--- a/packages/changesets-renovate/src/__tests__/git-utils.test.ts
+++ b/packages/changesets-renovate/src/__tests__/git-utils.test.ts
@@ -8,6 +8,24 @@ vi.mock('yaml')
 vi.mock('tinyglobby')
 vi.mock('node:fs/promises')
 
+const mockParseCatalog = (content: string) =>
+  content.includes('1.0.0')
+    ? {
+        catalog: {
+          'package-a': '1.0.0',
+          'package-b': '2.0.0',
+          'package-c': '3.0.0',
+        },
+      }
+    : {
+        catalog: {
+          'package-a': '1.1.0',
+          'package-b': '2.0.0',
+          'package-c': '3.1.0',
+          'package-d': '4.0.0',
+        },
+      }
+
 describe('pnpm-catalogs-git-utils', () => {
   beforeEach(() => {
     // Clear all mocks
@@ -94,27 +112,7 @@ catalog:
 `),
       })
 
-      // Mock yaml parsing
-      vi.mocked(parse).mockImplementation((content: string) => {
-        if (content.includes('1.0.0')) {
-          return {
-            catalog: {
-              'package-a': '1.0.0',
-              'package-b': '2.0.0',
-              'package-c': '3.0.0',
-            },
-          }
-        }
-
-        return {
-          catalog: {
-            'package-a': '1.1.0',
-            'package-b': '2.0.0',
-            'package-c': '3.1.0',
-            'package-d': '4.0.0',
-          },
-        }
-      })
+      vi.mocked(parse).mockImplementation(mockParseCatalog)
 
       const result = await findChangedDependenciesFromGit('abc123', 'def456')
 

--- a/packages/changesets-renovate/src/__tests__/utils.test.ts
+++ b/packages/changesets-renovate/src/__tests__/utils.test.ts
@@ -38,6 +38,24 @@ vi.mock(import('@changesets/config'), async importOriginal => {
   }
 })
 
+const enoent = (): never => {
+  const error = new Error('not found') as NodeJS.ErrnoException
+  error.code = 'ENOENT'
+  throw error
+}
+
+const mockReadFileMap = (files: Record<string, string>, fallback: 'enoent' | '{}' = 'enoent') => {
+  vi.mocked(readFile).mockImplementation((async (filePath: string) => {
+    if (filePath in files) {
+      return files[filePath]
+    }
+    if (fallback === 'enoent') {
+      enoent()
+    }
+    return '{}'
+  }) as any)
+}
+
 describe('pnpm-catalogs-utils', () => {
   beforeEach(() => {
     // Clear all mocks
@@ -179,15 +197,9 @@ catalog:
 
   describe(getWorkspacePackageGlobs, () => {
     it('should discover globs from pnpm-workspace.yaml', async () => {
-      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
-        if (filePath === 'pnpm-workspace.yaml') {
-          return 'packages:\n  - packages/*\n  - apps/*'
-        }
-
-        const error = new Error('not found') as NodeJS.ErrnoException
-        error.code = 'ENOENT'
-        throw error
-      }) as any)
+      mockReadFileMap({
+        'pnpm-workspace.yaml': 'packages:\n  - packages/*\n  - apps/*',
+      })
       vi.mocked(parse).mockReturnValue({ packages: ['packages/*', 'apps/*'] })
 
       const result = await getWorkspacePackageGlobs()
@@ -196,15 +208,9 @@ catalog:
     })
 
     it('should discover globs from root package.json workspaces', async () => {
-      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
-        if (filePath === 'package.json') {
-          return JSON.stringify({ workspaces: ['packages/*', 'tools/*'] })
-        }
-
-        const error = new Error('not found') as NodeJS.ErrnoException
-        error.code = 'ENOENT'
-        throw error
-      }) as any)
+      mockReadFileMap({
+        'package.json': JSON.stringify({ workspaces: ['packages/*', 'tools/*'] }),
+      })
 
       const result = await getWorkspacePackageGlobs()
 
@@ -212,15 +218,9 @@ catalog:
     })
 
     it('should support workspaces as { packages: [] } object', async () => {
-      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
-        if (filePath === 'package.json') {
-          return JSON.stringify({ workspaces: { packages: ['apps/*'] } })
-        }
-
-        const error = new Error('not found') as NodeJS.ErrnoException
-        error.code = 'ENOENT'
-        throw error
-      }) as any)
+      mockReadFileMap({
+        'package.json': JSON.stringify({ workspaces: { packages: ['apps/*'] } }),
+      })
 
       const result = await getWorkspacePackageGlobs()
 
@@ -228,16 +228,13 @@ catalog:
     })
 
     it('should merge and deduplicate globs from both sources', async () => {
-      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
-        if (filePath === 'pnpm-workspace.yaml') {
-          return 'packages:\n  - packages/*'
-        }
-        if (filePath === 'package.json') {
-          return JSON.stringify({ workspaces: ['packages/*', 'apps/*'] })
-        }
-
-        return '{}'
-      }) as any)
+      mockReadFileMap(
+        {
+          'pnpm-workspace.yaml': 'packages:\n  - packages/*',
+          'package.json': JSON.stringify({ workspaces: ['packages/*', 'apps/*'] }),
+        },
+        '{}',
+      )
       vi.mocked(parse).mockReturnValue({ packages: ['packages/*'] })
 
       const result = await getWorkspacePackageGlobs()
@@ -258,15 +255,9 @@ catalog:
     })
 
     it('should strip trailing slashes from workspace patterns', async () => {
-      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
-        if (filePath === 'pnpm-workspace.yaml') {
-          return 'packages:\n  - packages/*/'
-        }
-
-        const error = new Error('not found') as NodeJS.ErrnoException
-        error.code = 'ENOENT'
-        throw error
-      }) as any)
+      mockReadFileMap({
+        'pnpm-workspace.yaml': 'packages:\n  - packages/*/',
+      })
       vi.mocked(parse).mockReturnValue({ packages: ['packages/*/'] })
 
       const result = await getWorkspacePackageGlobs()
@@ -297,28 +288,25 @@ catalog:
 
     it('should find packages affected by dependency changes', async () => {
       // Mock file system reads for package.json files
-      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
-        if (filePath === 'packages/package-a/package.json') {
-          return JSON.stringify({
+      mockReadFileMap(
+        {
+          'packages/package-a/package.json': JSON.stringify({
             dependencies: {
               'changed-dep': 'catalog:',
             },
             version: '1.0.0',
             name: 'package-a',
-          })
-        }
-        if (filePath === 'packages/package-b/package.json') {
-          return JSON.stringify({
+          }),
+          'packages/package-b/package.json': JSON.stringify({
             dependencies: {
               'unchanged-dep': 'catalog:',
             },
             version: '1.0.0',
             name: 'package-b',
-          })
-        }
-
-        return '{}'
-      }) as any)
+          }),
+        },
+        '{}',
+      )
 
       const result = await findAffectedPackages(['changed-dep'])
 
@@ -341,28 +329,25 @@ catalog:
       process.env['EXCLUDE_DEVDEPS'] = 'true'
 
       // Mock file system reads for package.json files
-      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
-        if (filePath === 'packages/package-a/package.json') {
-          return JSON.stringify({
+      mockReadFileMap(
+        {
+          'packages/package-a/package.json': JSON.stringify({
             dependencies: {
               'changed-dep': 'catalog:',
             },
             version: '1.0.0',
             name: 'package-a',
-          })
-        }
-        if (filePath === 'packages/package-b/package.json') {
-          return JSON.stringify({
+          }),
+          'packages/package-b/package.json': JSON.stringify({
             devDependencies: {
               'changed-dep': 'catalog:',
             },
             version: '1.0.0',
             name: 'package-b',
-          })
-        }
-
-        return '{}'
-      }) as any)
+          }),
+        },
+        '{}',
+      )
 
       const result = await findAffectedPackages(['changed-dep'])
 
@@ -385,37 +370,32 @@ catalog:
       })
 
       // Mock file system reads for package.json files
-      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
-        if (filePath === 'packages/package-a/package.json') {
-          return JSON.stringify({
+      mockReadFileMap(
+        {
+          'packages/package-a/package.json': JSON.stringify({
             dependencies: {
               'changed-dep': 'catalog:',
             },
             version: '1.0.0',
             name: 'package-a',
-          })
-        }
-        if (filePath === 'packages/package-b/package.json') {
-          return JSON.stringify({
+          }),
+          'packages/package-b/package.json': JSON.stringify({
             dependencies: {
               'unchanged-dep': 'catalog:',
             },
             version: '1.0.0',
             name: 'package-b',
-          })
-        }
-        if (filePath === 'packages/package-c/package.json') {
-          return JSON.stringify({
+          }),
+          'packages/package-c/package.json': JSON.stringify({
             dependencies: {
               'changed-dep': 'catalog:',
             },
             version: '1.0.0',
             name: 'package-c',
-          })
-        }
-
-        return '{}'
-      }) as any)
+          }),
+        },
+        '{}',
+      )
 
       const result = await findAffectedPackages(['changed-dep'])
 
@@ -467,19 +447,18 @@ catalog:
 
     it('should respect explicitly provided packageJsonGlobs over discovered ones', async () => {
       vi.mocked(glob).mockResolvedValue(['apps/app-a/package.json'])
-      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
-        if (filePath === 'apps/app-a/package.json') {
-          return JSON.stringify({
+      mockReadFileMap(
+        {
+          'apps/app-a/package.json': JSON.stringify({
             dependencies: {
               'changed-dep': 'catalog:',
             },
             version: '1.0.0',
             name: 'app-a',
-          })
-        }
-
-        return '{}'
-      }) as any)
+          }),
+        },
+        '{}',
+      )
 
       const result = await findAffectedPackages(['changed-dep'], ['apps/*/package.json'])
 
@@ -493,24 +472,16 @@ catalog:
     })
 
     it('should discover non-default workspace layouts (apps/*) from pnpm-workspace.yaml', async () => {
-      vi.mocked(readFile).mockImplementation((async (filePath: string) => {
-        if (filePath === 'pnpm-workspace.yaml') {
-          return 'packages:\n  - apps/*'
-        }
-        if (filePath === 'apps/app-a/package.json') {
-          return JSON.stringify({
-            dependencies: {
-              'changed-dep': 'catalog:',
-            },
-            version: '1.0.0',
-            name: 'app-a',
-          })
-        }
-
-        const error = new Error('not found') as NodeJS.ErrnoException
-        error.code = 'ENOENT'
-        throw error
-      }) as any)
+      mockReadFileMap({
+        'pnpm-workspace.yaml': 'packages:\n  - apps/*',
+        'apps/app-a/package.json': JSON.stringify({
+          dependencies: {
+            'changed-dep': 'catalog:',
+          },
+          version: '1.0.0',
+          name: 'app-a',
+        }),
+      })
       vi.mocked(parse).mockReturnValue({ packages: ['apps/*'] })
       vi.mocked(glob).mockResolvedValue(['apps/app-a/package.json'])
 

--- a/packages/scouter/src/__tests__/integration.test.tsx
+++ b/packages/scouter/src/__tests__/integration.test.tsx
@@ -7,6 +7,17 @@ import { describe, expect, it, test } from 'vitest'
 import { MemoryRouter, Redirect, Route, Switch, useLocation, useNavigate } from '../index'
 import { Router } from '../Router'
 
+const navigateOnFirstRender = (count: number, navigate: (path: string) => void, setCount: (n: number) => void) => {
+  if (count !== 0) {
+    return
+  }
+  Promise.resolve().then(() => {
+    navigate('/intermediate')
+    setCount(1)
+    navigate('/final')
+  })
+}
+
 test('renders routes correctly', () => {
   render(
     <MemoryRouter initialEntries={['/users/123']}>
@@ -138,17 +149,7 @@ test('batches multiple navigations in a microtask (no intermediate render)', asy
     const [count, setCount] = useState(0)
 
     useEffect(() => {
-      if (count === 0) {
-        // Simulate the real-world scenario: navigate + setState inside a
-        // microtask (Promise continuation). With useSyncExternalStore the
-        // first navigate would trigger a synchronous re-render before
-        // setCount runs, causing the component to see '/intermediate'.
-        Promise.resolve().then(() => {
-          navigate('/intermediate')
-          setCount(1)
-          navigate('/final')
-        })
-      }
+      navigateOnFirstRender(count, navigate, setCount)
     }, [count, navigate])
 
     return <Tracker />

--- a/packages/use-dataloader/src/__tests__/DataLoaderProvider.test.tsx
+++ b/packages/use-dataloader/src/__tests__/DataLoaderProvider.test.tsx
@@ -119,11 +119,8 @@ describe('dataLoaderProvider', () => {
     expect(reloads).toHaveProperty(TEST_KEY)
     const testReload = result.current.getReloads(TEST_KEY)
     expect(testReload).toBeDefined()
-    if (testReload) {
-      await expect(testReload()).resolves.toBeNull()
-    } else {
-      throw new Error('It shoulded be defined')
-    }
+    expect(testReload).toBeDefined()
+    await expect(testReload!()).resolves.toBeNull()
     expect(result.current.getCachedData(TEST_KEY)).toBeNull()
     expect(result.current.getCachedData()).toStrictEqual({ test: null })
     expect(result.current.getRequest(TEST_KEY)).toBeDefined()

--- a/packages/use-dataloader/src/__tests__/useDataLoader.test.tsx
+++ b/packages/use-dataloader/src/__tests__/useDataLoader.test.tsx
@@ -22,6 +22,26 @@ const fakeSuccessPromise = async () =>
     }, PROMISE_TIMEOUT)
   })
 
+const createPollingPromise = (getFlag: () => boolean, value: unknown) => async () =>
+  new Promise(resolve => {
+    setInterval(() => {
+      if (getFlag()) {
+        resolve(value)
+      }
+    }, PROMISE_TIMEOUT)
+  })
+
+const createSuccessOrErrorPromise = (getSuccess: () => boolean, error: Error) =>
+  new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (getSuccess()) {
+        resolve(true)
+      } else {
+        reject(error)
+      }
+    }, PROMISE_TIMEOUT)
+  })
+
 const initialProps = {
   config: {
     enabled: true,
@@ -92,18 +112,7 @@ describe(useDataLoader, () => {
 
   it('should render correctly without request enabled then enable it', async () => {
     let resolveIt = false
-    const method = vi.fn(async () => {
-      const promiseFn = async () =>
-        new Promise(resolve => {
-          setInterval(() => {
-            if (resolveIt) {
-              resolve(true)
-            }
-          }, PROMISE_TIMEOUT)
-        })
-
-      return promiseFn()
-    })
+    const method = vi.fn(createPollingPromise(() => resolveIt, true))
     const testProps = {
       config: {
         enabled: false,
@@ -179,18 +188,7 @@ describe(useDataLoader, () => {
 
   it('should render and cache correctly with cacheKeyPrefix', async () => {
     let resolveIt = false
-    const method = vi.fn(async () => {
-      const promiseFn = async () =>
-        new Promise(resolve => {
-          setInterval(() => {
-            if (resolveIt) {
-              resolve(true)
-            }
-          }, PROMISE_TIMEOUT)
-        })
-
-      return promiseFn()
-    })
+    const method = vi.fn(createPollingPromise(() => resolveIt, true))
 
     const initProps = {
       ...initialProps,
@@ -525,18 +523,7 @@ describe(useDataLoader, () => {
 
   it('should render correctly with enabled off', async () => {
     let resolveIt = false
-    const method = vi.fn(async () => {
-      const promiseFn = async () =>
-        new Promise(resolve => {
-          setInterval(() => {
-            if (resolveIt) {
-              resolve(true)
-            }
-          }, PROMISE_TIMEOUT)
-        })
-
-      return promiseFn()
-    })
+    const method = vi.fn(createPollingPromise(() => resolveIt, true))
 
     const initProps = {
       ...initialProps,
@@ -703,16 +690,7 @@ describe(useDataLoader, () => {
           onSuccess,
         },
         key: 'test-12',
-        method: async () =>
-          new Promise((resolve, reject) => {
-            setTimeout(() => {
-              if (success) {
-                resolve(true)
-              } else {
-                reject(error)
-              }
-            }, PROMISE_TIMEOUT)
-          }),
+        method: async () => createSuccessOrErrorPromise(() => success, error),
       },
       wrapper,
     })
@@ -937,18 +915,7 @@ describe(useDataLoader, () => {
 
   it('should differentiate between isLoading and isFetching', async () => {
     let resolveIt = false
-    const method = vi.fn(async () => {
-      const promiseFn = async () =>
-        new Promise(resolve => {
-          setInterval(() => {
-            if (resolveIt) {
-              resolve({ id: 1, name: 'test' })
-            }
-          }, PROMISE_TIMEOUT)
-        })
-
-      return promiseFn()
-    })
+    const method = vi.fn(createPollingPromise(() => resolveIt, { id: 1, name: 'test' }))
 
     const testProps = {
       config: {

--- a/packages/use-growthbook/src/__tests__/AbTestProvider.test.tsx
+++ b/packages/use-growthbook/src/__tests__/AbTestProvider.test.tsx
@@ -162,26 +162,25 @@ describe('abTestProvider', () => {
     getAttributes.mockReturnValue({ anonymousId: 'foo' })
 
     // Re-render with different attributes
-    if (rerenderFn) {
-      await act(async () => {
-        rerenderFn!(
-          <AbTestProvider
-            attributes={{
-              anonymousId: 'bar',
-            }}
-            config={{
-              apiHost: 'host',
-              clientKey: 'clientKey',
-              enableDevMode: true,
-            }}
-            errorCallback={errorCallback}
-            trackingCallback={trackingCallback}
-          >
-            Children
-          </AbTestProvider>,
-        )
-      })
-    }
+    expect(rerenderFn).toBeDefined()
+    await act(async () => {
+      rerenderFn!(
+        <AbTestProvider
+          attributes={{
+            anonymousId: 'bar',
+          }}
+          config={{
+            apiHost: 'host',
+            clientKey: 'clientKey',
+            enableDevMode: true,
+          }}
+          errorCallback={errorCallback}
+          trackingCallback={trackingCallback}
+        >
+          Children
+        </AbTestProvider>,
+      )
+    })
 
     // Wait for useEffect to run
     await new Promise(resolve => {
@@ -225,20 +224,19 @@ describe('abTestProvider', () => {
     getAttributes.mockReturnValue(getAttributesReturn)
 
     // Re-render with the SAME EXACT object references
-    if (rerenderFn) {
-      await act(async () => {
-        rerenderFn!(
-          <AbTestProvider
-            attributes={sharedAttributes} // Same config object
-            config={config} // Same attributes object
-            errorCallback={errorCallback}
-            trackingCallback={trackingCallback}
-          >
-            Children
-          </AbTestProvider>,
-        )
-      })
-    }
+    expect(rerenderFn).toBeDefined()
+    await act(async () => {
+      rerenderFn!(
+        <AbTestProvider
+          attributes={sharedAttributes} // Same config object
+          config={config} // Same attributes object
+          errorCallback={errorCallback}
+          trackingCallback={trackingCallback}
+        >
+          Children
+        </AbTestProvider>,
+      )
+    })
 
     // Mock getAttributes to return the same object reference on re-render
     getAttributes.mockReturnValue(getAttributesReturn)

--- a/packages/use-i18n/src/__tests__/usei18n.test.tsx
+++ b/packages/use-i18n/src/__tests__/usei18n.test.tsx
@@ -1,6 +1,7 @@
 // oxlint-disable max-lines
 import { act, renderHook } from '@testing-library/react'
 import { enGB, fr as frDateFns } from 'date-fns/locale'
+import type { BaseLocale } from 'international-types'
 import { MissingValueError } from 'intl-messageformat'
 import type { ComponentProps, ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -35,6 +36,16 @@ const CustomComponent = ({ children }: { children: ReactNode }) => <p style={{ f
 
 const defaultOnTranslateError: OnTranslateError = () => undefined
 const defaultOnLoadTranslationError: OnLoadTranslationError = () => undefined
+
+const mockLoadRejectByLocale =
+  (rejectLocale: string, error: Error, resolveValue: BaseLocale): LoadTranslationsFn<Locales> =>
+  ({ locale }) =>
+    locale === rejectLocale ? Promise.reject(error) : Promise.resolve({ default: resolveValue })
+
+const mockLoadRejectByNamespace =
+  (rejectNamespace: string, error: Error, resolveValue: BaseLocale): LoadTranslationsFn<Locales> =>
+  ({ namespace }) =>
+    namespace === rejectNamespace ? Promise.reject(error) : Promise.resolve({ default: resolveValue })
 
 const wrapper =
   ({
@@ -952,12 +963,11 @@ describe('i18n hook', () => {
     it('should call onLoadTranslationError when loading translation fails for default locale', async () => {
       expect.hasAssertions()
       const mockOnLoadTranslationError = vi.fn<OnLoadTranslationError>()
-      const mockLoad = vi.fn<LoadTranslationsFn<Locales>>().mockImplementation(({ locale }) => {
-        if (locale === 'en') {
-          return Promise.reject(new Error('Default locale load failed'))
-        }
-        return Promise.resolve({ default: { title: 'Titre en français' } })
-      })
+      const mockLoad = vi
+        .fn<LoadTranslationsFn<Locales>>()
+        .mockImplementation(
+          mockLoadRejectByLocale('en', new Error('Default locale load failed'), { title: 'Titre en français' }),
+        )
 
       const { result } = renderHook(() => useTranslation<Locale, Locales>(['test'], mockLoad), {
         wrapper: wrapper({
@@ -982,12 +992,11 @@ describe('i18n hook', () => {
     it('should continue loading current locale even if default locale fails', async () => {
       expect.hasAssertions()
       const mockOnLoadTranslationError = vi.fn<OnLoadTranslationError>()
-      const mockLoad = vi.fn<LoadTranslationsFn<Locales>>().mockImplementation(({ locale }) => {
-        if (locale === 'en') {
-          return Promise.reject(new Error('Default locale load failed'))
-        }
-        return Promise.resolve({ default: { title: 'French Title' } })
-      })
+      const mockLoad = vi
+        .fn<LoadTranslationsFn<Locales>>()
+        .mockImplementation(
+          mockLoadRejectByLocale('en', new Error('Default locale load failed'), { title: 'French Title' }),
+        )
 
       const { result } = renderHook(() => useTranslation<Locale, Locales>(['test'], mockLoad), {
         wrapper: wrapper({
@@ -1023,12 +1032,9 @@ describe('i18n hook', () => {
     it('should call onLoadTranslationError for each namespace that fails', async () => {
       expect.hasAssertions()
       const mockOnLoadTranslationError = vi.fn<OnLoadTranslationError>()
-      const mockLoad = vi.fn<LoadTranslationsFn<Locales>>().mockImplementation(({ namespace }) => {
-        if (namespace === 'user') {
-          return Promise.reject(new Error('User namespace failed'))
-        }
-        return Promise.resolve({ default: { name: 'Name' } })
-      })
+      const mockLoad = vi
+        .fn<LoadTranslationsFn<Locales>>()
+        .mockImplementation(mockLoadRejectByNamespace('user', new Error('User namespace failed'), { name: 'Name' }))
 
       const { result } = renderHook(() => useTranslation<NamespaceLocale, Locales>(['user', 'profile'], mockLoad), {
         wrapper: wrapper({
@@ -1046,12 +1052,11 @@ describe('i18n hook', () => {
     it('should handle errors when switching locale fails', async () => {
       expect.hasAssertions()
       const mockOnLoadTranslationError = vi.fn<OnLoadTranslationError>()
-      const mockLoad = vi.fn<LoadTranslationsFn<Locales>>().mockImplementation(({ locale }) => {
-        if (locale === 'fr') {
-          return Promise.reject(new Error('French locale load failed'))
-        }
-        return Promise.resolve({ default: { title: 'English Title' } })
-      })
+      const mockLoad = vi
+        .fn<LoadTranslationsFn<Locales>>()
+        .mockImplementation(
+          mockLoadRejectByLocale('fr', new Error('French locale load failed'), { title: 'English Title' }),
+        )
 
       const { result } = renderHook(() => useTranslation<Locale, Locales>(['test'], mockLoad), {
         wrapper: wrapper({

--- a/packages/validate-icu-locales/src/__tests__/validate-icu-locales.test.ts
+++ b/packages/validate-icu-locales/src/__tests__/validate-icu-locales.test.ts
@@ -12,12 +12,10 @@ describe('validate-icu-locales CLI', () => {
       expect.fail('Expected command to fail with ICU errors')
     } catch (error) {
       // Check that the error contains information about ICU syntax errors
-      if (error instanceof Error) {
-        const errorMessage = error.toString()
-        // The CLI outputs errors to stderr and exits with code 1
-        expect(errorMessage).toContain('errors')
-        expect(errorMessage).toContain('EXPECT_ARGUMENT_CLOSING_BRACE')
-      }
+      const errorMessage = (error as Error).toString()
+      // The CLI outputs errors to stderr and exits with code 1
+      expect(errorMessage).toContain('errors')
+      expect(errorMessage).toContain('EXPECT_ARGUMENT_CLOSING_BRACE')
     }
   })
 


### PR DESCRIPTION
Refs #3773

Fixed all 44 violations of `vitest/no-conditional-in-test` across 9 test files and removed the rule from `oxlint.config.ts`.

**Strategy:** Moved conditionals (if/else, ternaries, `&&`) inside test blocks into module-scope helper functions, since the rule flags all conditional expressions lexically inside test bodies.

**Files changed:**
- `validate-icu-locales` test — replaced `if (error instanceof Error)` with direct cast
- `git-utils` test — extracted mock parse logic to module-scope helper
- `DataLoaderProvider` test — replaced `if/else` guard with assertion + non-null assertion
- `scouter` integration test — extracted useEffect conditional to module-scope function
- `AbTestProvider` test — replaced `if (rerenderFn)` guards with assertions
- `usei18n` test — extracted mock load implementations to module-scope helpers
- `useDataLoader` test — extracted polling/success-or-error promise factories to module scope
- `generate-changeset` test — extracted mock readFile dispatch to module-scope helper
- `utils` test — extracted mock readFile dispatch to module-scope helper

Part of [Oxlint v1](https://github.com/scaleway/scaleway-lib/milestone/2).