### PR TITLE
fix(oxlint): fix vitest/require-mock-type-parameters violations

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -16,7 +16,6 @@ export default defineConfig({
         'vitest/prefer-import-in-mock': 'warn',
         'vitest/prefer-spy-on': 'warn',
         'vitest/prefer-strict-equal': 'warn',
-        'vitest/require-mock-type-parameters': 'warn',
       },
     },
   ],

--- a/packages/auth-scw/src/__tests__/AuthScwProvider.test.tsx
+++ b/packages/auth-scw/src/__tests__/AuthScwProvider.test.tsx
@@ -6,8 +6,10 @@ import { MOCK_AUDIENCE_ID, MOCK_ENCODED_JWT_COOKIE } from '../../mocks/index'
 import { AuthScwProvider, useAuthScw } from '../useAuthScw/AuthScwProvider'
 import { AuthStoreManager } from '../useAuthScw/authStoreManager'
 
-const mockDeleteJwt = vi.fn(() => Promise.resolve())
-const mockRenewJwt = vi.fn(() => Promise.resolve(MOCK_ENCODED_JWT_COOKIE))
+const mockDeleteJwt = vi.fn<() => Promise<void>>(() => Promise.resolve())
+const mockRenewJwt = vi.fn<() => Promise<typeof MOCK_ENCODED_JWT_COOKIE>>(() =>
+  Promise.resolve(MOCK_ENCODED_JWT_COOKIE),
+)
 
 const DEFAULT_COOKIE_SUFFIX = 'test'
 
@@ -64,7 +66,7 @@ describe('useauthscw provider', () => {
     })
 
     it('should inject a token within cookie at login if token url param is present', async () => {
-      const mockReplaceStateHistory = vi.fn()
+      const mockReplaceStateHistory = vi.fn<() => void>()
 
       const currentUrl = new URL(globalThis.location.href)
 

--- a/packages/changesets-renovate/__mocks__/simple-git.ts
+++ b/packages/changesets-renovate/__mocks__/simple-git.ts
@@ -1,14 +1,14 @@
 import { vi } from 'vitest'
 
 export const defaultGitValues = {
-  add: () => undefined,
+  add: (): void => undefined,
   branch: () => ({
     current: '',
   }),
-  commit: () => undefined,
+  commit: (): void => undefined,
   diffSummary: () => ({}),
-  push: () => undefined,
-  revparse: () => undefined,
+  push: (): void => undefined,
+  revparse: (): string => '',
   show: () => '',
 }
 

--- a/packages/changesets-renovate/src/__tests__/generate-changeset.test.ts
+++ b/packages/changesets-renovate/src/__tests__/generate-changeset.test.ts
@@ -12,7 +12,7 @@ vi.mock(import('@changesets/config'), async importOriginal => {
 
   return {
     ...actual,
-    readConfig: vi.fn().mockResolvedValue({ config: actual.defaultConfig, warnings: [], errors: undefined }),
+    readConfig: vi.fn<() => any>().mockResolvedValue({ config: actual.defaultConfig, warnings: [], errors: undefined }),
   }
 })
 
@@ -60,10 +60,10 @@ describe('generate changeset file', () => {
     const rev = 'test'
     const fileName = `.changeset/renovate-${rev}.md`
     const file = 'test/package.json'
-    const revparse = vi.fn().mockReturnValue(rev)
-    const add = vi.fn()
-    const commit = vi.fn()
-    const push = vi.fn()
+    const revparse = vi.fn<() => any>().mockReturnValue(rev)
+    const add = vi.fn<() => undefined>()
+    const commit = vi.fn<() => undefined>()
+    const push = vi.fn<() => undefined>()
 
     mockSimpleGit.mockReturnValue({
       add,
@@ -106,10 +106,10 @@ describe('generate changeset file', () => {
     const rev = 'test'
     const fileName = `.changeset/renovate-${rev}.md`
     const file = 'test/package.json'
-    const revparse = vi.fn().mockReturnValue(rev)
-    const add = vi.fn()
-    const commit = vi.fn()
-    const push = vi.fn()
+    const revparse = vi.fn<() => any>().mockReturnValue(rev)
+    const add = vi.fn<() => undefined>()
+    const commit = vi.fn<() => undefined>()
+    const push = vi.fn<() => undefined>()
 
     mockSimpleGit.mockReturnValue({
       add,
@@ -190,10 +190,10 @@ describe('generate changeset file', () => {
     const rev = 'test'
     const fileName = `.changeset/renovate-${rev}.md`
     const file = 'test/package.json'
-    const revparse = vi.fn().mockReturnValue(rev)
-    const add = vi.fn()
-    const commit = vi.fn()
-    const push = vi.fn()
+    const revparse = vi.fn<() => any>().mockReturnValue(rev)
+    const add = vi.fn<() => undefined>()
+    const commit = vi.fn<() => undefined>()
+    const push = vi.fn<() => undefined>()
 
     mockSimpleGit.mockReturnValue({
       add,
@@ -234,10 +234,10 @@ describe('generate changeset file', () => {
     const rev = 'test'
     const fileName = `.changeset/renovate-${rev}.md`
     const file = 'test/package.json'
-    const revparse = vi.fn().mockReturnValue(rev)
-    const add = vi.fn()
-    const commit = vi.fn()
-    const push = vi.fn()
+    const revparse = vi.fn<() => any>().mockReturnValue(rev)
+    const add = vi.fn<() => undefined>()
+    const commit = vi.fn<() => undefined>()
+    const push = vi.fn<() => undefined>()
 
     mockSimpleGit.mockReturnValue({
       add,
@@ -280,10 +280,10 @@ describe('generate changeset file', () => {
     const fileName = `.changeset/renovate-${rev}.md`
     const fileA = 'test-a/package.json'
     const fileB = 'test-b/package.json'
-    const revparse = vi.fn().mockReturnValue(rev)
-    const add = vi.fn()
-    const commit = vi.fn()
-    const push = vi.fn()
+    const revparse = vi.fn<() => any>().mockReturnValue(rev)
+    const add = vi.fn<() => undefined>()
+    const commit = vi.fn<() => undefined>()
+    const push = vi.fn<() => undefined>()
 
     mockSimpleGit.mockReturnValue({
       add,

--- a/packages/changesets-renovate/src/__tests__/generate-changeset.test.ts
+++ b/packages/changesets-renovate/src/__tests__/generate-changeset.test.ts
@@ -60,10 +60,10 @@ describe('generate changeset file', () => {
     const rev = 'test'
     const fileName = `.changeset/renovate-${rev}.md`
     const file = 'test/package.json'
-    const revparse = vi.fn<() => any>().mockReturnValue(rev)
-    const add = vi.fn<() => undefined>()
-    const commit = vi.fn<() => undefined>()
-    const push = vi.fn<() => undefined>()
+    const revparse = vi.fn<() => string>().mockReturnValue(rev)
+    const add = vi.fn<() => void>()
+    const commit = vi.fn<() => void>()
+    const push = vi.fn<() => void>()
 
     mockSimpleGit.mockReturnValue({
       add,
@@ -106,10 +106,10 @@ describe('generate changeset file', () => {
     const rev = 'test'
     const fileName = `.changeset/renovate-${rev}.md`
     const file = 'test/package.json'
-    const revparse = vi.fn<() => any>().mockReturnValue(rev)
-    const add = vi.fn<() => undefined>()
-    const commit = vi.fn<() => undefined>()
-    const push = vi.fn<() => undefined>()
+    const revparse = vi.fn<() => string>().mockReturnValue(rev)
+    const add = vi.fn<() => void>()
+    const commit = vi.fn<() => void>()
+    const push = vi.fn<() => void>()
 
     mockSimpleGit.mockReturnValue({
       add,
@@ -190,10 +190,10 @@ describe('generate changeset file', () => {
     const rev = 'test'
     const fileName = `.changeset/renovate-${rev}.md`
     const file = 'test/package.json'
-    const revparse = vi.fn<() => any>().mockReturnValue(rev)
-    const add = vi.fn<() => undefined>()
-    const commit = vi.fn<() => undefined>()
-    const push = vi.fn<() => undefined>()
+    const revparse = vi.fn<() => string>().mockReturnValue(rev)
+    const add = vi.fn<() => void>()
+    const commit = vi.fn<() => void>()
+    const push = vi.fn<() => void>()
 
     mockSimpleGit.mockReturnValue({
       add,
@@ -234,10 +234,10 @@ describe('generate changeset file', () => {
     const rev = 'test'
     const fileName = `.changeset/renovate-${rev}.md`
     const file = 'test/package.json'
-    const revparse = vi.fn<() => any>().mockReturnValue(rev)
-    const add = vi.fn<() => undefined>()
-    const commit = vi.fn<() => undefined>()
-    const push = vi.fn<() => undefined>()
+    const revparse = vi.fn<() => string>().mockReturnValue(rev)
+    const add = vi.fn<() => void>()
+    const commit = vi.fn<() => void>()
+    const push = vi.fn<() => void>()
 
     mockSimpleGit.mockReturnValue({
       add,
@@ -280,10 +280,10 @@ describe('generate changeset file', () => {
     const fileName = `.changeset/renovate-${rev}.md`
     const fileA = 'test-a/package.json'
     const fileB = 'test-b/package.json'
-    const revparse = vi.fn<() => any>().mockReturnValue(rev)
-    const add = vi.fn<() => undefined>()
-    const commit = vi.fn<() => undefined>()
-    const push = vi.fn<() => undefined>()
+    const revparse = vi.fn<() => string>().mockReturnValue(rev)
+    const add = vi.fn<() => void>()
+    const commit = vi.fn<() => void>()
+    const push = vi.fn<() => void>()
 
     mockSimpleGit.mockReturnValue({
       add,

--- a/packages/changesets-renovate/src/__tests__/generate-changeset.test.ts
+++ b/packages/changesets-renovate/src/__tests__/generate-changeset.test.ts
@@ -12,7 +12,9 @@ vi.mock(import('@changesets/config'), async importOriginal => {
 
   return {
     ...actual,
-    readConfig: vi.fn<() => any>().mockResolvedValue({ config: actual.defaultConfig, warnings: [], errors: undefined }),
+    readConfig: vi
+      .fn<typeof readConfig>()
+      .mockResolvedValue({ config: actual.defaultConfig, warnings: [], errors: undefined }),
   }
 })
 

--- a/packages/changesets-renovate/src/__tests__/git-utils.test.ts
+++ b/packages/changesets-renovate/src/__tests__/git-utils.test.ts
@@ -40,13 +40,13 @@ catalog:
   another-package: 2.0.0
 `
       mockSimpleGit.mockReturnValue({
-        add: vi.fn(),
-        branch: vi.fn(),
-        commit: vi.fn(),
-        diffSummary: vi.fn(),
-        push: vi.fn(),
-        revparse: vi.fn(),
-        show: vi.fn().mockResolvedValue(mockContent),
+        add: vi.fn<() => undefined>(),
+        branch: vi.fn<() => { current: string }>(),
+        commit: vi.fn<() => undefined>(),
+        diffSummary: vi.fn<() => {}>(),
+        push: vi.fn<() => undefined>(),
+        revparse: vi.fn<() => undefined>(),
+        show: vi.fn<() => any>().mockResolvedValue(mockContent),
       })
       vi.mocked(parse).mockReturnValue({
         catalog: {
@@ -67,13 +67,13 @@ catalog:
 
     it('should return empty object if git operation fails', async () => {
       mockSimpleGit.mockReturnValue({
-        add: vi.fn(),
-        branch: vi.fn(),
-        commit: vi.fn(),
-        diffSummary: vi.fn(),
-        push: vi.fn(),
-        revparse: vi.fn(),
-        show: vi.fn().mockRejectedValue(new Error('File not found')),
+        add: vi.fn<() => undefined>(),
+        branch: vi.fn<() => { current: string }>(),
+        commit: vi.fn<() => undefined>(),
+        diffSummary: vi.fn<() => {}>(),
+        push: vi.fn<() => undefined>(),
+        revparse: vi.fn<() => undefined>(),
+        show: vi.fn<() => any>().mockRejectedValue(new Error('File not found')),
       })
 
       const result = await loadCatalogFromGit('nonexistent', 'pnpm-workspace.yaml')
@@ -92,13 +92,13 @@ catalog:
     it('should find dependencies that have changed between git revisions', async () => {
       // Mock the git operations
       mockSimpleGit.mockReturnValue({
-        add: vi.fn(),
-        branch: vi.fn(),
-        commit: vi.fn(),
-        diffSummary: vi.fn(),
-        push: vi.fn(),
-        revparse: vi.fn(),
-        show: vi.fn().mockResolvedValueOnce(`
+        add: vi.fn<() => undefined>(),
+        branch: vi.fn<() => { current: string }>(),
+        commit: vi.fn<() => undefined>(),
+        diffSummary: vi.fn<() => {}>(),
+        push: vi.fn<() => undefined>(),
+        revparse: vi.fn<() => undefined>(),
+        show: vi.fn<() => any>().mockResolvedValueOnce(`
 catalog:
   package-a: 1.0.0
   package-b: 2.0.0

--- a/packages/changesets-renovate/src/__tests__/git-utils.test.ts
+++ b/packages/changesets-renovate/src/__tests__/git-utils.test.ts
@@ -46,7 +46,7 @@ catalog:
         diffSummary: vi.fn<() => Record<string, unknown>>(),
         push: vi.fn<() => void>(),
         revparse: vi.fn<() => string>(),
-        show: vi.fn<() => any>().mockResolvedValue(mockContent),
+        show: vi.fn<() => string>().mockReturnValue(mockContent),
       })
       vi.mocked(parse).mockReturnValue({
         catalog: {
@@ -73,7 +73,9 @@ catalog:
         diffSummary: vi.fn<() => Record<string, unknown>>(),
         push: vi.fn<() => void>(),
         revparse: vi.fn<() => string>(),
-        show: vi.fn<() => any>().mockRejectedValue(new Error('File not found')),
+        show: vi.fn<() => string>().mockImplementation(() => {
+          throw new Error('File not found')
+        }),
       })
 
       const result = await loadCatalogFromGit('nonexistent', 'pnpm-workspace.yaml')
@@ -98,12 +100,12 @@ catalog:
         diffSummary: vi.fn<() => Record<string, unknown>>(),
         push: vi.fn<() => void>(),
         revparse: vi.fn<() => string>(),
-        show: vi.fn<() => any>().mockResolvedValueOnce(`
+        show: vi.fn<() => string>().mockReturnValueOnce(`
 catalog:
   package-a: 1.0.0
   package-b: 2.0.0
   package-c: 3.0.0
-`).mockResolvedValueOnce(`
+`).mockReturnValueOnce(`
 catalog:
   package-a: 1.1.0
   package-b: 2.0.0

--- a/packages/changesets-renovate/src/__tests__/git-utils.test.ts
+++ b/packages/changesets-renovate/src/__tests__/git-utils.test.ts
@@ -40,12 +40,12 @@ catalog:
   another-package: 2.0.0
 `
       mockSimpleGit.mockReturnValue({
-        add: vi.fn<() => undefined>(),
+        add: vi.fn<() => void>(),
         branch: vi.fn<() => { current: string }>(),
-        commit: vi.fn<() => undefined>(),
-        diffSummary: vi.fn<() => {}>(),
-        push: vi.fn<() => undefined>(),
-        revparse: vi.fn<() => undefined>(),
+        commit: vi.fn<() => void>(),
+        diffSummary: vi.fn<() => Record<string, unknown>>(),
+        push: vi.fn<() => void>(),
+        revparse: vi.fn<() => string>(),
         show: vi.fn<() => any>().mockResolvedValue(mockContent),
       })
       vi.mocked(parse).mockReturnValue({
@@ -67,12 +67,12 @@ catalog:
 
     it('should return empty object if git operation fails', async () => {
       mockSimpleGit.mockReturnValue({
-        add: vi.fn<() => undefined>(),
+        add: vi.fn<() => void>(),
         branch: vi.fn<() => { current: string }>(),
-        commit: vi.fn<() => undefined>(),
-        diffSummary: vi.fn<() => {}>(),
-        push: vi.fn<() => undefined>(),
-        revparse: vi.fn<() => undefined>(),
+        commit: vi.fn<() => void>(),
+        diffSummary: vi.fn<() => Record<string, unknown>>(),
+        push: vi.fn<() => void>(),
+        revparse: vi.fn<() => string>(),
         show: vi.fn<() => any>().mockRejectedValue(new Error('File not found')),
       })
 
@@ -92,12 +92,12 @@ catalog:
     it('should find dependencies that have changed between git revisions', async () => {
       // Mock the git operations
       mockSimpleGit.mockReturnValue({
-        add: vi.fn<() => undefined>(),
+        add: vi.fn<() => void>(),
         branch: vi.fn<() => { current: string }>(),
-        commit: vi.fn<() => undefined>(),
-        diffSummary: vi.fn<() => {}>(),
-        push: vi.fn<() => undefined>(),
-        revparse: vi.fn<() => undefined>(),
+        commit: vi.fn<() => void>(),
+        diffSummary: vi.fn<() => Record<string, unknown>>(),
+        push: vi.fn<() => void>(),
+        revparse: vi.fn<() => string>(),
         show: vi.fn<() => any>().mockResolvedValueOnce(`
 catalog:
   package-a: 1.0.0

--- a/packages/changesets-renovate/src/__tests__/globWithGitignore.test.ts
+++ b/packages/changesets-renovate/src/__tests__/globWithGitignore.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { globWithGitignore } from '../globWithGitignore.js'
 
 const { execSyncMock, escapePathMock, globMock } = vi.hoisted(() => ({
-  execSyncMock: vi.fn(() => 'node_modules/\ndist/\n'),
-  escapePathMock: vi.fn((p: string) => p),
-  globMock: vi.fn(),
+  execSyncMock: vi.fn<() => string>(() => 'node_modules/\ndist/\n'),
+  escapePathMock: vi.fn<(p: string) => string>((p: string) => p),
+  globMock: vi.fn<() => Promise<string[]>>(),
 }))
 
 vi.mock('node:child_process', () => ({

--- a/packages/changesets-renovate/src/__tests__/handle-catalog.test.ts
+++ b/packages/changesets-renovate/src/__tests__/handle-catalog.test.ts
@@ -82,7 +82,7 @@ describe('handle-catalog', () => {
 
     // Mock simpleGit to return a short hash
     mockSimpleGit.mockReturnValue({
-      revparse: vi.fn().mockResolvedValue('abc123\n'),
+      revparse: vi.fn<() => Promise<string>>().mockResolvedValue('abc123\n'),
     } as any)
 
     // Mock createChangeset and handleChangesetFile

--- a/packages/changesets-renovate/src/__tests__/handle-packages.test.ts
+++ b/packages/changesets-renovate/src/__tests__/handle-packages.test.ts
@@ -61,7 +61,7 @@ describe('handle-packages', () => {
 
     // Mock simpleGit to return a short hash
     mockSimpleGit.mockReturnValue({
-      revparse: vi.fn().mockResolvedValue('def456\n'),
+      revparse: vi.fn<() => Promise<string>>().mockResolvedValue('def456\n'),
     } as any)
 
     // Mock getBumpsFromGit to return some bumps

--- a/packages/changesets-renovate/src/__tests__/utils.test.ts
+++ b/packages/changesets-renovate/src/__tests__/utils.test.ts
@@ -34,7 +34,9 @@ vi.mock(import('@changesets/config'), async importOriginal => {
 
   return {
     ...actual,
-    readConfig: vi.fn<() => any>().mockResolvedValue({ config: actual.defaultConfig, warnings: [], errors: undefined }),
+    readConfig: vi
+      .fn<typeof readConfig>()
+      .mockResolvedValue({ config: actual.defaultConfig, warnings: [], errors: undefined }),
   }
 })
 

--- a/packages/changesets-renovate/src/__tests__/utils.test.ts
+++ b/packages/changesets-renovate/src/__tests__/utils.test.ts
@@ -13,9 +13,9 @@ import {
 } from '../utils.js'
 
 const { execSyncMock, escapePathMock, globMock } = vi.hoisted(() => ({
-  execSyncMock: vi.fn(() => 'node_modules/\ndist/\n'),
-  escapePathMock: vi.fn((p: string) => p),
-  globMock: vi.fn(),
+  execSyncMock: vi.fn<() => string>(() => 'node_modules/\ndist/\n'),
+  escapePathMock: vi.fn<(p: string) => string>((p: string) => p),
+  globMock: vi.fn<() => Promise<string[]>>(),
 }))
 
 // Mock all external dependencies
@@ -34,7 +34,7 @@ vi.mock(import('@changesets/config'), async importOriginal => {
 
   return {
     ...actual,
-    readConfig: vi.fn().mockResolvedValue({ config: actual.defaultConfig, warnings: [], errors: undefined }),
+    readConfig: vi.fn<() => any>().mockResolvedValue({ config: actual.defaultConfig, warnings: [], errors: undefined }),
   }
 })
 

--- a/packages/use-analytics/src/__tests__/CookieConsentProvider.test.tsx
+++ b/packages/use-analytics/src/__tests__/CookieConsentProvider.test.tsx
@@ -31,7 +31,7 @@ vi.mock('../constants', () => ({
 }))
 
 vi.mock('../helpers/misc', () => ({
-  stringToHash: vi.fn((str: string) => `hash_${str}`),
+  stringToHash: vi.fn<(str: string) => string>((str: string) => `hash_${str}`),
 }))
 
 const TestComponent = () => {

--- a/packages/use-clipboard/src/__tests__/index.test.ts
+++ b/packages/use-clipboard/src/__tests__/index.test.ts
@@ -5,14 +5,14 @@ import { copyToClipboard, useClipboard } from '../'
 describe(copyToClipboard, () => {
   beforeEach(() => {
     Object.defineProperty(navigator, 'clipboard', {
-      value: { writeText: vi.fn() },
+      value: { writeText: vi.fn<() => void>() },
       writable: true,
       configurable: true,
     })
   })
 
   it('should copy text to clipboard successfully', async () => {
-    const writeTextSpy = vi.fn().mockResolvedValue(undefined)
+    const writeTextSpy = vi.fn<(data: string) => Promise<void>>().mockResolvedValue(undefined)
     navigator.clipboard.writeText = writeTextSpy
 
     await copyToClipboard('test text')
@@ -22,9 +22,9 @@ describe(copyToClipboard, () => {
 
   it('should call onError callback when clipboard fails', async () => {
     const error = new Error('Clipboard error')
-    const writeTextSpy = vi.fn().mockRejectedValue(error)
+    const writeTextSpy = vi.fn<(data: string) => Promise<void>>().mockRejectedValue(error)
     navigator.clipboard.writeText = writeTextSpy
-    const onErrorSpy = vi.fn()
+    const onErrorSpy = vi.fn<() => void>()
 
     await copyToClipboard('test text', { onError: onErrorSpy })
 
@@ -34,7 +34,7 @@ describe(copyToClipboard, () => {
 
   it('should handle clipboard error without onError callback', async () => {
     const error = new Error('Clipboard error')
-    const writeTextSpy = vi.fn().mockRejectedValue(error)
+    const writeTextSpy = vi.fn<(data: string) => Promise<void>>().mockRejectedValue(error)
     navigator.clipboard.writeText = writeTextSpy
 
     await expect(copyToClipboard('test text')).resolves.toBeUndefined()
@@ -46,7 +46,7 @@ describe('hooks - useClipboard', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     Object.defineProperty(navigator, 'clipboard', {
-      value: { writeText: vi.fn() },
+      value: { writeText: vi.fn<() => void>() },
       writable: true,
       configurable: true,
     })
@@ -57,7 +57,7 @@ describe('hooks - useClipboard', () => {
   })
 
   it('should copy text to clipboard successfully', async () => {
-    const writeTextSpy = vi.fn().mockResolvedValue(undefined)
+    const writeTextSpy = vi.fn<(data: string) => Promise<void>>().mockResolvedValue(undefined)
     navigator.clipboard.writeText = writeTextSpy
 
     const { result } = renderHook(() => useClipboard('test text'))
@@ -72,7 +72,7 @@ describe('hooks - useClipboard', () => {
 
   it('should handle clipboard error', async () => {
     const error = new Error('Clipboard error')
-    const writeTextSpy = vi.fn().mockRejectedValue(error)
+    const writeTextSpy = vi.fn<(data: string) => Promise<void>>().mockRejectedValue(error)
     navigator.clipboard.writeText = writeTextSpy
 
     const { result } = renderHook(() => useClipboard('test text'))
@@ -86,9 +86,9 @@ describe('hooks - useClipboard', () => {
 
   it('should call onError callback when clipboard fails', async () => {
     const error = new Error('Clipboard error')
-    const writeTextSpy = vi.fn().mockRejectedValue(error)
+    const writeTextSpy = vi.fn<(data: string) => Promise<void>>().mockRejectedValue(error)
     navigator.clipboard.writeText = writeTextSpy
-    const onErrorSpy = vi.fn()
+    const onErrorSpy = vi.fn<() => void>()
 
     const { result } = renderHook(() => useClipboard('test text', { onError: onErrorSpy }))
 
@@ -101,7 +101,7 @@ describe('hooks - useClipboard', () => {
   })
 
   it('should reset isCopied status after successDuration', async () => {
-    const writeTextSpy = vi.fn().mockResolvedValue(undefined)
+    const writeTextSpy = vi.fn<(data: string) => Promise<void>>().mockResolvedValue(undefined)
     navigator.clipboard.writeText = writeTextSpy
 
     const { result } = renderHook(() => useClipboard('test text', { successDuration: 1000 }))
@@ -120,7 +120,7 @@ describe('hooks - useClipboard', () => {
   })
 
   it('should not reset isCopied status without successDuration', async () => {
-    const writeTextSpy = vi.fn().mockResolvedValue(undefined)
+    const writeTextSpy = vi.fn<(data: string) => Promise<void>>().mockResolvedValue(undefined)
     navigator.clipboard.writeText = writeTextSpy
 
     const { result } = renderHook(() => useClipboard('test text'))
@@ -137,7 +137,7 @@ describe('hooks - useClipboard', () => {
   })
 
   it('should clear timeout when component unmounts', async () => {
-    const writeTextSpy = vi.fn().mockResolvedValue(undefined)
+    const writeTextSpy = vi.fn<(data: string) => Promise<void>>().mockResolvedValue(undefined)
     navigator.clipboard.writeText = writeTextSpy
 
     const { unmount, result } = renderHook(() => useClipboard('test text', { successDuration: 1000 }))
@@ -153,7 +153,7 @@ describe('hooks - useClipboard', () => {
   })
 
   it('should update clipboard text when text prop changes', async () => {
-    const writeTextSpy = vi.fn().mockResolvedValue(undefined)
+    const writeTextSpy = vi.fn<(data: string) => Promise<void>>().mockResolvedValue(undefined)
     navigator.clipboard.writeText = writeTextSpy
 
     const { result, rerender } = renderHook(({ text }) => useClipboard(text), {

--- a/packages/use-dataloader/src/__tests__/DataLoaderProvider.test.tsx
+++ b/packages/use-dataloader/src/__tests__/DataLoaderProvider.test.tsx
@@ -37,7 +37,7 @@ describe('dataLoaderProvider', () => {
   })
 
   it('should add request', async () => {
-    const method = vi.fn(fakePromise)
+    const method = vi.fn<typeof fakePromise>(fakePromise)
     const { result, rerender } = renderHook(useDataLoaderContext, {
       wrapper,
     })
@@ -72,7 +72,7 @@ describe('dataLoaderProvider', () => {
   })
 
   it('should add request with cache key prefix', async () => {
-    const method = vi.fn(fakePromise)
+    const method = vi.fn<typeof fakePromise>(fakePromise)
     const { result } = renderHook(useDataLoaderContext, {
       wrapper: wrapperWithCacheKey,
     })
@@ -105,7 +105,7 @@ describe('dataLoaderProvider', () => {
   })
 
   it('should add request with result is null', async () => {
-    const method = vi.fn(fakeNullPromise)
+    const method = vi.fn<typeof fakeNullPromise>(fakeNullPromise)
     const { result } = renderHook(useDataLoaderContext, {
       wrapper,
     })
@@ -138,7 +138,7 @@ describe('dataLoaderProvider', () => {
   })
 
   it('should delay max concurrent request', async () => {
-    const method = vi.fn(
+    const method = vi.fn<() => Promise<boolean>>(
       async () =>
         new Promise(resolve => {
           setTimeout(() => {
@@ -181,9 +181,9 @@ describe('dataLoaderProvider', () => {
   })
 
   it('should reload group', async () => {
-    const method1 = vi.fn(fakePromise)
-    const method2 = vi.fn(fakePromise)
-    const method3 = vi.fn(fakePromise)
+    const method1 = vi.fn<typeof fakePromise>(fakePromise)
+    const method2 = vi.fn<typeof fakePromise>(fakePromise)
+    const method3 = vi.fn<typeof fakePromise>(fakePromise)
 
     const { result } = renderHook(useDataLoaderContext, {
       wrapper,
@@ -223,9 +223,9 @@ describe('dataLoaderProvider', () => {
   })
 
   it('should reload all active requests', async () => {
-    const method1 = vi.fn(fakePromise)
-    const method2 = vi.fn(fakePromise)
-    const method3 = vi.fn(fakePromise)
+    const method1 = vi.fn<typeof fakePromise>(fakePromise)
+    const method2 = vi.fn<typeof fakePromise>(fakePromise)
+    const method3 = vi.fn<typeof fakePromise>(fakePromise)
 
     const { result } = renderHook(useDataLoaderContext, {
       wrapper,
@@ -249,9 +249,9 @@ describe('dataLoaderProvider', () => {
   })
 
   it('should reload group active requests', async () => {
-    const method1 = vi.fn(fakePromise)
-    const method2 = vi.fn(fakePromise)
-    const method3 = vi.fn(fakePromise)
+    const method1 = vi.fn<typeof fakePromise>(fakePromise)
+    const method2 = vi.fn<typeof fakePromise>(fakePromise)
+    const method3 = vi.fn<typeof fakePromise>(fakePromise)
 
     const { result } = renderHook(useDataLoaderContext, {
       wrapper,

--- a/packages/use-dataloader/src/__tests__/dataloader.test.ts
+++ b/packages/use-dataloader/src/__tests__/dataloader.test.ts
@@ -41,8 +41,8 @@ const fakeLongErrorPromise = async () =>
 
 describe('dataloader class', () => {
   it('should create instance then load then destroy', async () => {
-    const method = vi.fn(fakeSuccessPromise)
-    const notifyChanges = vi.fn()
+    const method = vi.fn<typeof fakeSuccessPromise>(fakeSuccessPromise)
+    const notifyChanges = vi.fn<() => void>()
     const instance = new DataLoader({
       key: 'test-destroy',
       method,
@@ -56,8 +56,8 @@ describe('dataloader class', () => {
   })
 
   it('should create instance then load multiple times', async () => {
-    const method = vi.fn(fakeSuccessPromise)
-    const notifyChanges = vi.fn()
+    const method = vi.fn<typeof fakeSuccessPromise>(fakeSuccessPromise)
+    const notifyChanges = vi.fn<() => void>()
     const instance = new DataLoader({
       key: 'test-load',
       method,
@@ -73,8 +73,8 @@ describe('dataloader class', () => {
   })
 
   it('should create instance with cancel', () => {
-    const notify = vi.fn()
-    const method = vi.fn(fakeSuccessPromise)
+    const notify = vi.fn<() => void>()
+    const method = vi.fn<typeof fakeSuccessPromise>(fakeSuccessPromise)
     const instance = new DataLoader({
       key: 'test-cancel',
       method,
@@ -95,8 +95,8 @@ describe('dataloader class', () => {
   })
 
   it('should create instance without cancel', async () => {
-    const notify = vi.fn()
-    const method = vi.fn(fakeSuccessPromise)
+    const notify = vi.fn<() => void>()
+    const method = vi.fn<typeof fakeSuccessPromise>(fakeSuccessPromise)
     const instance = new DataLoader({
       key: 'test-without-cancel',
       method,
@@ -111,8 +111,8 @@ describe('dataloader class', () => {
   })
 
   it('should create instance with null data', async () => {
-    const method = vi.fn(fakeNullPromise)
-    const notifyChanges = vi.fn()
+    const method = vi.fn<typeof fakeNullPromise>(fakeNullPromise)
+    const notifyChanges = vi.fn<() => void>()
     const instance = new DataLoader({
       key: 'test-null',
       method,
@@ -124,8 +124,8 @@ describe('dataloader class', () => {
   })
 
   it('should create instance with undefined data', async () => {
-    const method = vi.fn(fakeUndefinedPromise)
-    const notifyChanges = vi.fn()
+    const method = vi.fn<typeof fakeUndefinedPromise>(fakeUndefinedPromise)
+    const notifyChanges = vi.fn<() => void>()
 
     const instance = new DataLoader({
       key: 'test-undefined',
@@ -138,9 +138,9 @@ describe('dataloader class', () => {
   })
 
   it('should create instance with error', async () => {
-    const method = vi.fn(fakeErrorPromise)
-    const notifyChanges = vi.fn()
-    const onError = vi.fn()
+    const method = vi.fn<typeof fakeErrorPromise>(fakeErrorPromise)
+    const notifyChanges = vi.fn<() => void>()
+    const onError = vi.fn<() => void>()
 
     const instance = new DataLoader({
       key: 'test-error',
@@ -153,8 +153,8 @@ describe('dataloader class', () => {
   })
 
   it('should create instance with cancel and properly set status after', async () => {
-    const method = vi.fn(fakeSuccessPromise)
-    const notifyChanges = vi.fn()
+    const method = vi.fn<typeof fakeSuccessPromise>(fakeSuccessPromise)
+    const notifyChanges = vi.fn<() => void>()
 
     const instance = new DataLoader({
       key: 'test-cancel',
@@ -175,9 +175,9 @@ describe('dataloader class', () => {
   })
 
   it('should create instance with error and cancel', async () => {
-    const method = vi.fn(fakeLongErrorPromise)
-    const notifyChanges = vi.fn()
-    const onError = vi.fn()
+    const method = vi.fn<typeof fakeLongErrorPromise>(fakeLongErrorPromise)
+    const notifyChanges = vi.fn<() => void>()
+    const onError = vi.fn<() => void>()
 
     const instance = new DataLoader({
       key: 'test-error-cancel',
@@ -197,8 +197,8 @@ describe('dataloader class', () => {
   })
 
   it('should launch multiple dataloader', async () => {
-    const method = vi.fn(fakeErrorPromise)
-    const notifyChanges = vi.fn()
+    const method = vi.fn<typeof fakeErrorPromise>(fakeErrorPromise)
+    const notifyChanges = vi.fn<() => void>()
 
     const instances = Array.from({ length: 5 }, (_, index) => index).map(
       index =>

--- a/packages/use-dataloader/src/__tests__/useDataLoader.test.tsx
+++ b/packages/use-dataloader/src/__tests__/useDataLoader.test.tsx
@@ -48,7 +48,7 @@ const initialProps = {
     keepPreviousData: true,
   },
   key: 'test',
-  method: vi.fn(fakeSuccessPromise),
+  method: vi.fn<typeof fakeSuccessPromise>(fakeSuccessPromise),
 }
 const wrapper = ({ children }: { children?: ReactNode }) => <DataLoaderProvider>{children}</DataLoaderProvider>
 
@@ -112,7 +112,7 @@ describe(useDataLoader, () => {
 
   it('should render correctly without request enabled then enable it', async () => {
     let resolveIt = false
-    const method = vi.fn(createPollingPromise(() => resolveIt, true))
+    const method = vi.fn<() => Promise<unknown>>(createPollingPromise(() => resolveIt, true))
     const testProps = {
       config: {
         enabled: false,
@@ -188,7 +188,7 @@ describe(useDataLoader, () => {
 
   it('should render and cache correctly with cacheKeyPrefix', async () => {
     let resolveIt = false
-    const method = vi.fn(createPollingPromise(() => resolveIt, true))
+    const method = vi.fn<() => Promise<unknown>>(createPollingPromise(() => resolveIt, true))
 
     const initProps = {
       ...initialProps,
@@ -301,7 +301,7 @@ describe(useDataLoader, () => {
         pollingInterval: 1000,
       },
       key: 'test-6',
-      method: vi.fn(
+      method: vi.fn<() => Promise<boolean>>(
         async () =>
           new Promise(resolve => {
             setTimeout(() => {
@@ -311,7 +311,7 @@ describe(useDataLoader, () => {
       ),
     } as UseDataLoaderHookProps
 
-    const method2 = vi.fn(
+    const method2 = vi.fn<() => Promise<number>>(
       async () =>
         new Promise(resolve => {
           setTimeout(() => {
@@ -399,7 +399,7 @@ describe(useDataLoader, () => {
         pollingInterval: undefined,
       },
       key: 'test-needpolling-no-interval',
-      method: vi.fn(
+      method: vi.fn<() => Promise<boolean>>(
         async () =>
           new Promise(resolve => {
             setTimeout(() => {
@@ -431,7 +431,7 @@ describe(useDataLoader, () => {
         pollingInterval: 1000,
       },
       key: 'test-needpolling-no-interval',
-      method: vi.fn(
+      method: vi.fn<() => Promise<boolean>>(
         async () =>
           new Promise(resolve => {
             setTimeout(() => {
@@ -463,7 +463,7 @@ describe(useDataLoader, () => {
         pollingInterval: PROMISE_TIMEOUT,
       },
       key: 'test-needpolling-no-interval',
-      method: vi.fn(
+      method: vi.fn<() => Promise<boolean>>(
         async () =>
           new Promise(resolve => {
             setTimeout(() => {
@@ -495,7 +495,7 @@ describe(useDataLoader, () => {
         pollingInterval: PROMISE_TIMEOUT,
       },
       key: 'test-needpolling-no-interval',
-      method: vi.fn(
+      method: vi.fn<() => Promise<boolean>>(
         async () =>
           new Promise(resolve => {
             setTimeout(() => {
@@ -523,7 +523,7 @@ describe(useDataLoader, () => {
 
   it('should render correctly with enabled off', async () => {
     let resolveIt = false
-    const method = vi.fn(createPollingPromise(() => resolveIt, true))
+    const method = vi.fn<() => Promise<unknown>>(createPollingPromise(() => resolveIt, true))
 
     const initProps = {
       ...initialProps,
@@ -554,7 +554,7 @@ describe(useDataLoader, () => {
   })
 
   it('should call onSuccess', async () => {
-    const onSuccess = vi.fn()
+    const onSuccess = vi.fn<() => void>()
     const { result } = renderHook(props => useDataLoader(props.key, props.method, props.config), {
       initialProps: {
         ...initialProps,
@@ -575,8 +575,8 @@ describe(useDataLoader, () => {
   })
 
   it('should call onError', async () => {
-    const onSuccess = vi.fn()
-    const onError = vi.fn()
+    const onSuccess = vi.fn<() => void>()
+    const onError = vi.fn<() => void>()
     const error = new Error('Test error')
     const { result } = renderHook(props => useDataLoader(props.key, props.method, props.config), {
       initialProps: {
@@ -608,10 +608,10 @@ describe(useDataLoader, () => {
   })
 
   it('should override onError from Provider', async () => {
-    const onSuccess = vi.fn()
-    const onError = vi.fn()
+    const onSuccess = vi.fn<() => void>()
+    const onError = vi.fn<() => void>()
     const error = new Error('Test error')
-    const onErrorProvider = vi.fn()
+    const onErrorProvider = vi.fn<() => void>()
     const { result } = renderHook(props => useDataLoader(props.key, props.method, props.config), {
       initialProps: {
         config: {
@@ -643,9 +643,9 @@ describe(useDataLoader, () => {
   })
 
   it('should call onError from Provider', async () => {
-    const onSuccess = vi.fn()
+    const onSuccess = vi.fn<() => void>()
     const error = new Error('Test error')
-    const onErrorProvider = vi.fn()
+    const onErrorProvider = vi.fn<() => void>()
     const { result } = renderHook(props => useDataLoader(props.key, props.method, props.config), {
       initialProps: {
         config: {
@@ -678,8 +678,8 @@ describe(useDataLoader, () => {
 
   it('should clear error on new response', async () => {
     let success = false
-    const onSuccess = vi.fn()
-    const onError = vi.fn(() => {
+    const onSuccess = vi.fn<() => void>()
+    const onError = vi.fn<() => void>(() => {
       success = true
     })
     const error = new Error('Test error')
@@ -716,7 +716,7 @@ describe(useDataLoader, () => {
   })
 
   it('should use cached data', async () => {
-    const fakePromise = vi.fn(initialProps.method)
+    const fakePromise = vi.fn<typeof initialProps.method>(initialProps.method)
     const testDate = new Date()
     const { result } = renderHook(
       props => [
@@ -772,7 +772,7 @@ describe(useDataLoader, () => {
   })
 
   it('should be reloaded from dataloader context', async () => {
-    const mockedFn = vi.fn(
+    const mockedFn = vi.fn<() => Promise<boolean>>(
       async () =>
         new Promise(resolve => {
           setTimeout(() => {
@@ -825,7 +825,7 @@ describe(useDataLoader, () => {
         enabled: false,
       },
       key: 'test-datalifetime',
-      method: vi.fn(fakeSuccessPromise),
+      method: vi.fn<typeof fakeSuccessPromise>(fakeSuccessPromise),
     }
     const { result, rerender } = renderHook(
       props => [
@@ -856,7 +856,7 @@ describe(useDataLoader, () => {
   })
 
   it('should render correctly with dataLifetime dont prevent double call', async () => {
-    const method = vi.fn(
+    const method = vi.fn<() => Promise<boolean>>(
       async () =>
         new Promise(resolve => {
           setTimeout(() => {
@@ -915,7 +915,7 @@ describe(useDataLoader, () => {
 
   it('should differentiate between isLoading and isFetching', async () => {
     let resolveIt = false
-    const method = vi.fn(createPollingPromise(() => resolveIt, { id: 1, name: 'test' }))
+    const method = vi.fn<() => Promise<unknown>>(createPollingPromise(() => resolveIt, { id: 1, name: 'test' }))
 
     const testProps = {
       config: {

--- a/packages/use-dataloader/src/__tests__/useInfiniteDataLoader.test.tsx
+++ b/packages/use-dataloader/src/__tests__/useInfiniteDataLoader.test.tsx
@@ -15,7 +15,7 @@ const config: UseInfiniteDataLoaderConfig<{ nextPage: number; data: string }, Er
 const getPrerequisite = (key: string) => {
   let counter = 1
   let canResolve = false
-  const getNextData = vi.fn(
+  const getNextData = vi.fn<() => Promise<{ nextPage: number; data: string }>>(
     async () =>
       new Promise<{ nextPage: number; data: string }>(resolve => {
         const resolvePromise = () => {
@@ -339,14 +339,14 @@ describe('useInfinitDataLoader', () => {
   })
 
   it('should call onError callback when request fails', async () => {
-    const onErrorMock = vi.fn()
+    const onErrorMock = vi.fn<() => void>()
     const { initialProps } = getPrerequisite('test-error')
     const localConfig = {
       ...config,
       onError: onErrorMock,
     }
 
-    const failingMethod = vi.fn(async () => {
+    const failingMethod = vi.fn<() => Promise<never>>(async () => {
       throw new Error('Network error')
     })
 
@@ -374,7 +374,7 @@ describe('useInfinitDataLoader', () => {
   })
 
   it('should call onSuccess callback when request succeeds', async () => {
-    const onSuccessMock = vi.fn()
+    const onSuccessMock = vi.fn<() => void>()
     const { setCanResolve, initialProps } = getPrerequisite('test-success')
     const localConfig = {
       ...config,
@@ -438,7 +438,7 @@ describe('useInfinitDataLoader', () => {
     }
 
     const { setCanResolve, initialProps } = getPrerequisite('test-no-next-page')
-    const localMethod = vi.fn(
+    const localMethod = vi.fn<() => Promise<{ nextPage: number | undefined; data: string }>>(
       async () =>
         new Promise<{ nextPage: number | undefined; data: string }>(resolve => {
           resolve({ data: 'Last page', nextPage: undefined })

--- a/packages/use-growthbook/src/__tests__/AbTestProvider.test.tsx
+++ b/packages/use-growthbook/src/__tests__/AbTestProvider.test.tsx
@@ -10,10 +10,10 @@ type TrackingCallback = ComponentProps<typeof AbTestProvider>['trackingCallback'
 
 type ErrorCallback = ComponentProps<typeof AbTestProvider>['errorCallback']
 
-const errorCallback: ErrorCallback = vi.fn()
+const errorCallback: ErrorCallback = vi.fn<() => void>()
 
 describe('abTestProvider', () => {
-  const trackingCallback: TrackingCallback = vi.fn()
+  const trackingCallback: TrackingCallback = vi.fn<() => void>()
 
   beforeEach(() => {
     vi.clearAllMocks()

--- a/packages/use-growthbook/src/__tests__/useAbTestAttributes.test.ts
+++ b/packages/use-growthbook/src/__tests__/useAbTestAttributes.test.ts
@@ -10,8 +10,8 @@ describe(useAbTestAttributes, () => {
 
     useGrowthBook.mockReturnValue({
       getAttributes,
-      init: vi.fn(),
-      loadFeatures: vi.fn(),
+      init: vi.fn<() => void>(),
+      loadFeatures: vi.fn<() => void>(),
       setAttributes,
     })
   })

--- a/packages/use-i18n/src/__tests__/usei18n.test.tsx
+++ b/packages/use-i18n/src/__tests__/usei18n.test.tsx
@@ -286,11 +286,11 @@ describe('i18n hook', () => {
       vi.spyOn(global, 'navigator', 'get').mockReturnValueOnce({
         languages: ['fr'],
       } as unknown as Navigator)
-      const mockGetItem = vi.fn().mockReturnValue('en')
-      const mockSetItem = vi.fn()
-      const mockRemoveItem = vi.fn()
+      const mockGetItem = vi.fn<() => string>().mockReturnValue('en')
+      const mockSetItem = vi.fn<() => void>()
+      const mockRemoveItem = vi.fn<() => void>()
       const localStorageMock = vi.spyOn(global, 'localStorage', 'get').mockReturnValue({
-        clear: vi.fn(),
+        clear: vi.fn<() => void>(),
         getItem: mockGetItem,
         removeItem: mockRemoveItem,
         setItem: mockSetItem,
@@ -315,11 +315,11 @@ describe('i18n hook', () => {
       vi.spyOn(global, 'navigator', 'get').mockReturnValueOnce({
         languages: ['bz'],
       } as unknown as Navigator)
-      const mockGetItem = vi.fn().mockReturnValue('re')
-      const mockSetItem = vi.fn()
-      const mockRemoveItem = vi.fn()
+      const mockGetItem = vi.fn<() => string>().mockReturnValue('re')
+      const mockSetItem = vi.fn<() => void>()
+      const mockRemoveItem = vi.fn<() => void>()
       const localStorageMock = vi.spyOn(global, 'localStorage', 'get').mockReturnValue({
-        clear: vi.fn(),
+        clear: vi.fn<() => void>(),
         getItem: mockGetItem,
         removeItem: mockRemoveItem,
         setItem: mockSetItem,
@@ -344,11 +344,11 @@ describe('i18n hook', () => {
       vi.spyOn(global, 'navigator', 'get').mockReturnValueOnce({
         languages: ['fr'],
       } as unknown as Navigator)
-      const mockGetItem = vi.fn()
-      const mockSetItem = vi.fn()
-      const mockRemoveItem = vi.fn()
+      const mockGetItem = vi.fn<() => void>()
+      const mockSetItem = vi.fn<() => void>()
+      const mockRemoveItem = vi.fn<() => void>()
       const localStorageMock = vi.spyOn(global, 'localStorage', 'get').mockReturnValueOnce({
-        clear: vi.fn(),
+        clear: vi.fn<() => void>(),
         getItem: mockGetItem,
         removeItem: mockRemoveItem,
         setItem: mockSetItem,
@@ -371,11 +371,11 @@ describe('i18n hook', () => {
       vi.spyOn(global, 'navigator', 'get').mockReturnValueOnce({
         languages: [],
       } as unknown as Navigator)
-      const mockGetItem = vi.fn()
-      const mockSetItem = vi.fn()
-      const mockRemoveItem = vi.fn()
+      const mockGetItem = vi.fn<() => void>()
+      const mockSetItem = vi.fn<() => void>()
+      const mockRemoveItem = vi.fn<() => void>()
       const localStorageMock = vi.spyOn(global, 'localStorage', 'get').mockReturnValueOnce({
-        clear: vi.fn(),
+        clear: vi.fn<() => void>(),
         getItem: mockGetItem,
         removeItem: mockRemoveItem,
         setItem: mockSetItem,
@@ -537,7 +537,7 @@ describe('i18n hook', () => {
   })
 
   it('should call onTranslateError when there is a sync issue to remove/add variable in one traduction of a language', async () => {
-    const mockOnTranslateError = vi.fn(() => undefined)
+    const mockOnTranslateError = vi.fn<() => void>(() => undefined)
 
     const { result } = renderHook(() => useI18n<Locale, Locales>(), {
       wrapper: wrapper({
@@ -903,11 +903,11 @@ describe('i18n hook', () => {
       vi.spyOn(global, 'navigator', 'get').mockReturnValueOnce({
         languages: ['fr'],
       } as unknown as Navigator)
-      const mockGetItem = vi.fn().mockReturnValue('fr')
-      const mockSetItem = vi.fn()
-      const mockRemoveItem = vi.fn()
+      const mockGetItem = vi.fn<() => string>().mockReturnValue('fr')
+      const mockSetItem = vi.fn<() => void>()
+      const mockRemoveItem = vi.fn<() => void>()
       const localStorageMock = vi.spyOn(global, 'localStorage', 'get').mockReturnValue({
-        clear: vi.fn(),
+        clear: vi.fn<() => void>(),
         getItem: mockGetItem,
         removeItem: mockRemoveItem,
         setItem: mockSetItem,

--- a/packages/use-interval/src/__tests__/index.test.tsx
+++ b/packages/use-interval/src/__tests__/index.test.tsx
@@ -14,7 +14,7 @@ describe('useinterval', () => {
   })
 
   it('should start with a delay of 100 ms', () => {
-    const callback = vi.fn()
+    const callback = vi.fn<() => void>()
     renderHook(() => {
       useInterval(callback, 100)
     })
@@ -24,7 +24,7 @@ describe('useinterval', () => {
   })
 
   it('should not start interval if null is passed', () => {
-    const callback = vi.fn()
+    const callback = vi.fn<() => void>()
     renderHook(() => {
       useInterval(callback, null)
     })


### PR DESCRIPTION
Refs #3781

Fixed all ~140 violations of `vitest/require-mock-type-parameters` across 17 test files and removed the rule from `oxlint.config.ts`.

**Strategy:** Added explicit type parameters to every `vi.fn()` call:
- Bare `vi.fn()` → `vi.fn<() => void>()`
- `vi.fn(impl)` → `vi.fn<typeof impl>(impl)` or typed with the actual return type where `() => void` broke assignability (e.g., `vi.fn<() => Promise<boolean>>(impl)`)
- Mocks with `.mockReturnValue()`/`.mockResolvedValue()` typed with their actual return type to satisfy vitest's `MockReturnType<T>`

**Files changed:**
- `changesets-renovate`: globWithGitignore, handle-packages, handle-catalog, git-utils, generate-changeset, utils tests
- `use-dataloader`: DataLoaderProvider, dataloader, useDataLoader, useInfiniteDataLoader tests
- `use-growthbook`: AbTestProvider, useAbTestAttributes tests
- `auth-scw`: AuthScwProvider test
- `use-analytics`: CookieConsentProvider test
- `use-interval`: index test
- `use-clipboard`: index test
- `use-i18n`: usei18n test

Part of [Oxlint v1](https://github.com/scaleway/scaleway-lib/milestone/2).