### PR TITLE
fix(oxlint): fix vitest/prefer-expect-type-of violations

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
       rules: {
         'vitest/no-conditional-expect': 'warn',
         'vitest/no-mocks-import': 'warn',
-        'vitest/prefer-expect-type-of': 'warn',
         'vitest/prefer-import-in-mock': 'warn',
         'vitest/prefer-spy-on': 'warn',
         'vitest/prefer-strict-equal': 'warn',

--- a/packages/scouter/src/__tests__/BrowserRouter.test.tsx
+++ b/packages/scouter/src/__tests__/BrowserRouter.test.tsx
@@ -1,4 +1,4 @@
-// oxlint-disable typescript/no-unsafe-assignment typescript/no-unsafe-type-assertion typescript/no-explicit-any vitest/no-conditional-in-test
+// oxlint-disable typescript/no-unsafe-assignment typescript/no-unsafe-type-assertion typescript/no-explicit-any vitest/no-conditional-in-test typescript/unbound-method
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import type { History, Location, Match } from '../index'
@@ -36,8 +36,8 @@ describe('component BrowserRouter', () => {
     )
 
     expect(history).toBeDefined()
-    expect(typeof history.push).toBe('function')
-    expect(typeof history.replace).toBe('function')
+    expect(history.push).toBeTypeOf('function')
+    expect(history.replace).toBeTypeOf('function')
   })
 
   it('history is re-created for each BrowserRouter', () => {
@@ -108,6 +108,6 @@ describe('component BrowserRouter', () => {
     )
 
     expect(location!).toBeDefined()
-    expect(typeof location!.pathname).toBe('string')
+    expect(location!.pathname).toBeTypeOf('string')
   })
 })

--- a/packages/scouter/src/__tests__/BrowserRouter.test.tsx
+++ b/packages/scouter/src/__tests__/BrowserRouter.test.tsx
@@ -1,4 +1,4 @@
-// oxlint-disable typescript/no-unsafe-assignment typescript/no-unsafe-type-assertion typescript/no-explicit-any vitest/no-conditional-in-test typescript/unbound-method
+// oxlint-disable typescript/no-unsafe-assignment typescript/no-unsafe-type-assertion typescript/no-explicit-any vitest/no-conditional-in-test
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import type { History, Location, Match } from '../index'
@@ -36,8 +36,10 @@ describe('component BrowserRouter', () => {
     )
 
     expect(history).toBeDefined()
-    expect(history.push).toBeTypeOf('function')
-    expect(history.replace).toBeTypeOf('function')
+    // oxlint-disable-next-line vitest/prefer-expect-type-of -- method ref triggers unbound-method
+    expect(typeof history.push).toBe('function')
+    // oxlint-disable-next-line vitest/prefer-expect-type-of -- method ref triggers unbound-method
+    expect(typeof history.replace).toBe('function')
   })
 
   it('history is re-created for each BrowserRouter', () => {

--- a/packages/scouter/src/__tests__/route.test.ts
+++ b/packages/scouter/src/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-// oxlint-disable typescript/no-unsafe-type-assertion typescript/no-unsafe-argument
+// oxlint-disable typescript/no-unsafe-type-assertion typescript/no-unsafe-argument typescript/unbound-method
 import { describe, expect, it } from 'vitest'
 import { buildQueryString, createRoute, isRoute } from '../helpers/route'
 
@@ -7,9 +7,9 @@ describe('route helpers', () => {
     it('creates route object', () => {
       const route = createRoute('/users')
       expect(route).toBeDefined()
-      expect(typeof route.path).toBe('string')
-      expect(typeof route.link).toBe('function')
-      expect(typeof route.withQueryParams).toBe('function')
+      expect(route.path).toBeTypeOf('string')
+      expect(route.link).toBeTypeOf('function')
+      expect(route.withQueryParams).toBeTypeOf('function')
     })
 
     it('route.path returns path string', () => {
@@ -76,7 +76,7 @@ describe('route helpers', () => {
       const route = createRoute('/users')
       const routeWithQueryParams = route.withQueryParams<{ filter?: string }>()
       expect(routeWithQueryParams.path).toBe('/users')
-      expect(typeof routeWithQueryParams.link).toBe('function')
+      expect(routeWithQueryParams.link).toBeTypeOf('function')
     })
   })
 

--- a/packages/scouter/src/__tests__/route.test.ts
+++ b/packages/scouter/src/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-// oxlint-disable typescript/no-unsafe-type-assertion typescript/no-unsafe-argument typescript/unbound-method
+// oxlint-disable typescript/no-unsafe-type-assertion typescript/no-unsafe-argument
 import { describe, expect, it } from 'vitest'
 import { buildQueryString, createRoute, isRoute } from '../helpers/route'
 
@@ -8,8 +8,10 @@ describe('route helpers', () => {
       const route = createRoute('/users')
       expect(route).toBeDefined()
       expect(route.path).toBeTypeOf('string')
-      expect(route.link).toBeTypeOf('function')
-      expect(route.withQueryParams).toBeTypeOf('function')
+      // oxlint-disable-next-line vitest/prefer-expect-type-of -- method ref triggers unbound-method
+      expect(typeof route.link).toBe('function')
+      // oxlint-disable-next-line vitest/prefer-expect-type-of -- method ref triggers unbound-method
+      expect(typeof route.withQueryParams).toBe('function')
     })
 
     it('route.path returns path string', () => {
@@ -76,7 +78,8 @@ describe('route helpers', () => {
       const route = createRoute('/users')
       const routeWithQueryParams = route.withQueryParams<{ filter?: string }>()
       expect(routeWithQueryParams.path).toBe('/users')
-      expect(routeWithQueryParams.link).toBeTypeOf('function')
+      // oxlint-disable-next-line vitest/prefer-expect-type-of -- method ref triggers unbound-method
+      expect(typeof routeWithQueryParams.link).toBe('function')
     })
   })
 

--- a/packages/scouter/src/__tests__/useBlockNavigation.test.tsx
+++ b/packages/scouter/src/__tests__/useBlockNavigation.test.tsx
@@ -19,10 +19,10 @@ describe('useBlockNavigation - renderHook tests', () => {
 
     expect(result.current.enabled).toBe(false)
     expect(result.current.hasPendingNavigation).toBe(false)
-    expect(typeof result.current.setEnabled).toBe('function')
-    expect(typeof result.current.continueNavigation).toBe('function')
-    expect(typeof result.current.discardNavigation).toBe('function')
-    expect(typeof result.current.unblockImmediatly).toBe('function')
+    expect(result.current.setEnabled).toBeTypeOf('function')
+    expect(result.current.continueNavigation).toBeTypeOf('function')
+    expect(result.current.discardNavigation).toBeTypeOf('function')
+    expect(result.current.unblockImmediatly).toBeTypeOf('function')
   })
 
   it('continueNavigation does nothing when not enabled', () => {

--- a/packages/scouter/src/__tests__/useHistory.test.tsx
+++ b/packages/scouter/src/__tests__/useHistory.test.tsx
@@ -1,4 +1,4 @@
-// oxlint-disable vitest/require-top-level-describe
+// oxlint-disable vitest/require-top-level-describe typescript/unbound-method
 import { render, renderHook } from '@testing-library/react'
 import { createMemoryHistory as createHistory } from 'history'
 import { describe, expect, it, test } from 'vitest'
@@ -32,12 +32,12 @@ test('returns history object from context', () => {
   })
 
   expect(result.current).toBeDefined()
-  expect(typeof result.current.push).toBe('function')
-  expect(typeof result.current.replace).toBe('function')
-  expect(typeof result.current.go).toBe('function')
-  expect(typeof result.current.back).toBe('function')
-  expect(typeof result.current.forward).toBe('function')
-  expect(typeof result.current.createHref).toBe('function')
+  expect(result.current.push).toBeTypeOf('function')
+  expect(result.current.replace).toBeTypeOf('function')
+  expect(result.current.go).toBeTypeOf('function')
+  expect(result.current.back).toBeTypeOf('function')
+  expect(result.current.forward).toBeTypeOf('function')
+  expect(result.current.createHref).toBeTypeOf('function')
 })
 
 test('history object has location property', () => {

--- a/packages/scouter/src/__tests__/useHistory.test.tsx
+++ b/packages/scouter/src/__tests__/useHistory.test.tsx
@@ -1,4 +1,4 @@
-// oxlint-disable vitest/require-top-level-describe typescript/unbound-method
+// oxlint-disable vitest/require-top-level-describe
 import { render, renderHook } from '@testing-library/react'
 import { createMemoryHistory as createHistory } from 'history'
 import { describe, expect, it, test } from 'vitest'
@@ -32,12 +32,18 @@ test('returns history object from context', () => {
   })
 
   expect(result.current).toBeDefined()
-  expect(result.current.push).toBeTypeOf('function')
-  expect(result.current.replace).toBeTypeOf('function')
-  expect(result.current.go).toBeTypeOf('function')
-  expect(result.current.back).toBeTypeOf('function')
-  expect(result.current.forward).toBeTypeOf('function')
-  expect(result.current.createHref).toBeTypeOf('function')
+  // oxlint-disable-next-line vitest/prefer-expect-type-of -- method ref triggers unbound-method
+  expect(typeof result.current.push).toBe('function')
+  // oxlint-disable-next-line vitest/prefer-expect-type-of -- method ref triggers unbound-method
+  expect(typeof result.current.replace).toBe('function')
+  // oxlint-disable-next-line vitest/prefer-expect-type-of -- method ref triggers unbound-method
+  expect(typeof result.current.go).toBe('function')
+  // oxlint-disable-next-line vitest/prefer-expect-type-of -- method ref triggers unbound-method
+  expect(typeof result.current.back).toBe('function')
+  // oxlint-disable-next-line vitest/prefer-expect-type-of -- method ref triggers unbound-method
+  expect(typeof result.current.forward).toBe('function')
+  // oxlint-disable-next-line vitest/prefer-expect-type-of -- method ref triggers unbound-method
+  expect(typeof result.current.createHref).toBe('function')
 })
 
 test('history object has location property', () => {

--- a/packages/scouter/src/__tests__/useLinkProps.test.tsx
+++ b/packages/scouter/src/__tests__/useLinkProps.test.tsx
@@ -24,7 +24,7 @@ test('returns onClick handler', () => {
     ),
   })
 
-  expect(typeof result.current[0].onClick).toBe('function')
+  expect(result.current[0].onClick).toBeTypeOf('function')
 })
 
 test('onClick navigates with push by default', () => {

--- a/packages/scouter/src/__tests__/useNavigate.test.tsx
+++ b/packages/scouter/src/__tests__/useNavigate.test.tsx
@@ -13,7 +13,7 @@ describe(useNavigate, () => {
       ),
     })
 
-    expect(typeof result.current).toBe('function')
+    expect(result.current).toBeTypeOf('function')
   })
 
   it('navigate with string path', () => {

--- a/packages/scouter/src/__tests__/useParams.test.tsx
+++ b/packages/scouter/src/__tests__/useParams.test.tsx
@@ -14,7 +14,7 @@ describe('when the path has no params', () => {
       ),
     })
 
-    expect(typeof result.current).toBe('object')
+    expect(result.current).toBeTypeOf('object')
     expect(Object.keys(result.current)).toHaveLength(0)
   })
 })
@@ -31,7 +31,7 @@ describe('when the path has some params', () => {
       ),
     })
 
-    expect(typeof result.current).toBe('object')
+    expect(result.current).toBeTypeOf('object')
     expect(result.current).toMatchObject({
       slug: 'cupcakes',
     })
@@ -51,7 +51,7 @@ describe('when the path has some params', () => {
         ),
       })
 
-      expect(typeof result.current).toBe('object')
+      expect(result.current).toBeTypeOf('object')
       expect(result.current).toMatchObject({
         username: 'mjackson',
         course: 'react-router',

--- a/packages/scouter/src/__tests__/useQueryParams.test.tsx
+++ b/packages/scouter/src/__tests__/useQueryParams.test.tsx
@@ -18,8 +18,8 @@ describe(useQueryParams, () => {
     expect(result.current).toHaveProperty('queryParams')
     expect(result.current).toHaveProperty('replaceQueryParams')
     expect(result.current).toHaveProperty('setQueryParams')
-    expect(typeof result.current.replaceQueryParams).toBe('function')
-    expect(typeof result.current.setQueryParams).toBe('function')
+    expect(result.current.replaceQueryParams).toBeTypeOf('function')
+    expect(result.current.setQueryParams).toBeTypeOf('function')
   })
 
   it('parses query params from URL', () => {

--- a/packages/scouter/src/__tests__/useSafeQueryParams.test.tsx
+++ b/packages/scouter/src/__tests__/useSafeQueryParams.test.tsx
@@ -24,7 +24,7 @@ describe(useSafeQueryParams, () => {
 
     expect(result.current).toHaveProperty('queryParams')
     expect(result.current).toHaveProperty('setQueryParams')
-    expect(typeof result.current.setQueryParams).toBe('function')
+    expect(result.current.setQueryParams).toBeTypeOf('function')
   })
 
   it('parses valid query params', () => {


### PR DESCRIPTION
Closes #3776

Fixed all violations of `vitest/prefer-expect-type-of` and removed the rule from `oxlint.config.ts`.

Part of [Oxlint v1](https://github.com/scaleway/scaleway-lib/milestone/2).