### PR TITLE
fix(oxlint): fix vitest/prefer-snapshot-hint violations

### DIFF
--- a/packages/changesets-renovate/src/__tests__/__snapshots__/generate-changeset.test.ts.snap
+++ b/packages/changesets-renovate/src/__tests__/__snapshots__/generate-changeset.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`generate changeset file > should generate changeset file, but skip commit and push 1`] = `
+exports[`generate changeset file > should generate changeset file, but skip commit and push > changeset without commit and push 1`] = `
 [MockFunction] {
   "calls": [
     [
@@ -23,7 +23,7 @@ Updated dependency \`package2\` to \`version2\`.
 }
 `;
 
-exports[`generate changeset file > should generate changeset file, commit and push 1`] = `
+exports[`generate changeset file > should generate changeset file, commit and push > changeset with commit and push 1`] = `
 [MockFunction] {
   "calls": [
     [
@@ -46,7 +46,7 @@ Updated dependency \`packagea\` to \`version\`.
 }
 `;
 
-exports[`generate changeset file > should generate sorted changeset file, but skip commit and push 1`] = `
+exports[`generate changeset file > should generate sorted changeset file, but skip commit and push > sorted changeset without commit and push 1`] = `
 [MockFunction] {
   "calls": [
     [
@@ -70,7 +70,7 @@ Updated dependency \`packagez\` to \`version2\`.
 }
 `;
 
-exports[`generate changeset file > should not skip if branch starts with custom branch prefix 1`] = `
+exports[`generate changeset file > should not skip if branch starts with custom branch prefix > custom branch prefix changeset 1`] = `
 [MockFunction] {
   "calls": [
     [
@@ -93,7 +93,7 @@ Updated dependency \`package2\` to \`version2\`.
 }
 `;
 
-exports[`generate changeset file > should not skip if not in renovate branch, when branch check skip is true 1`] = `
+exports[`generate changeset file > should not skip if not in renovate branch, when branch check skip is true > branch check skip changeset 1`] = `
 [MockFunction] {
   "calls": [
     [

--- a/packages/changesets-renovate/src/__tests__/generate-changeset.test.ts
+++ b/packages/changesets-renovate/src/__tests__/generate-changeset.test.ts
@@ -96,7 +96,7 @@ describe('generate changeset file', () => {
 
     expect(console.log).not.toHaveBeenCalledWith('Not a renovate branch, skipping')
     expect(mockedReadFile).toHaveBeenCalledWith(file, 'utf8')
-    expect(mockedWriteFile).toMatchSnapshot()
+    expect(mockedWriteFile).toMatchSnapshot('custom branch prefix changeset')
     expect(add).toHaveBeenCalledWith(fileName)
     expect(commit).toHaveBeenCalledWith(`chore: add ${fileName}`)
     expect(push).toHaveBeenCalledTimes(1)
@@ -142,7 +142,7 @@ describe('generate changeset file', () => {
 
     expect(console.log).not.toHaveBeenCalledWith('Not a renovate branch, skipping')
     expect(mockedReadFile).toHaveBeenCalledWith(file, 'utf8')
-    expect(mockedWriteFile).toMatchSnapshot()
+    expect(mockedWriteFile).toMatchSnapshot('branch check skip changeset')
     expect(add).toHaveBeenCalledWith(fileName)
     expect(commit).toHaveBeenCalledWith(`chore: add ${fileName}`)
     expect(push).toHaveBeenCalledTimes(1)
@@ -224,7 +224,7 @@ describe('generate changeset file', () => {
     await run()
 
     expect(mockedReadFile).toHaveBeenCalledWith(file, 'utf8')
-    expect(mockedWriteFile).toMatchSnapshot()
+    expect(mockedWriteFile).toMatchSnapshot('changeset with commit and push')
     expect(add).toHaveBeenCalledWith(fileName)
     expect(commit).toHaveBeenCalledWith(`chore: add ${fileName}`)
     expect(push).toHaveBeenCalledTimes(1)
@@ -269,7 +269,7 @@ describe('generate changeset file', () => {
     await run()
 
     expect(mockedReadFile).toHaveBeenCalledWith(file, 'utf8')
-    expect(mockedWriteFile).toMatchSnapshot()
+    expect(mockedWriteFile).toMatchSnapshot('changeset without commit and push')
     expect(add).not.toHaveBeenCalledWith(fileName)
     expect(commit).not.toHaveBeenCalledWith(`chore: add changeset renovate-${rev}`)
     expect(push).not.toHaveBeenCalledTimes(1)
@@ -321,7 +321,7 @@ describe('generate changeset file', () => {
 
     expect(mockedReadFile).toHaveBeenCalledWith(fileA, 'utf8')
     expect(mockedReadFile).toHaveBeenCalledWith(fileB, 'utf8')
-    expect(mockedWriteFile).toMatchSnapshot()
+    expect(mockedWriteFile).toMatchSnapshot('sorted changeset without commit and push')
     expect(add).not.toHaveBeenCalledWith(fileName)
     expect(commit).not.toHaveBeenCalledWith(`chore: add changeset renovate-${rev}`)
     expect(push).not.toHaveBeenCalledTimes(1)

--- a/packages/use-i18n/src/__tests__/__snapshots__/formatDate.test.ts.snap
+++ b/packages/use-i18n/src/__tests__/__snapshots__/formatDate.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`formatDate > should return passed object if not valid date 1`] = `
+exports[`formatDate > should return passed object if not valid date > invalid date 1`] = `
 {
   "not": "a valid date",
 }

--- a/packages/use-i18n/src/__tests__/__snapshots__/formatUnit.test.ts.snap
+++ b/packages/use-i18n/src/__tests__/__snapshots__/formatUnit.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`formatUnit > should return empty string for unknown unit 1`] = `""`;
+exports[`formatUnit > should return empty string for unknown unit > unknown unit 1`] = `""`;
 
 exports[`formatUnit > should work with { unit: 'bit' } 1`] = `"12,56 b"`;
 

--- a/packages/use-i18n/src/__tests__/formatDate.test.ts
+++ b/packages/use-i18n/src/__tests__/formatDate.test.ts
@@ -41,7 +41,7 @@ describe(formatDate, () => {
     expect(
       // @ts-expect-error we check a failing case
       formatDate('fr', { not: 'a valid date' }),
-    ).toMatchSnapshot()
+    ).toMatchSnapshot('invalid date')
   })
 
   it('should throw if shorthand format is invalid', () => {

--- a/packages/use-i18n/src/__tests__/formatUnit.test.ts
+++ b/packages/use-i18n/src/__tests__/formatUnit.test.ts
@@ -46,7 +46,7 @@ describe(formatUnit, () => {
     expect(
       // @ts-expect-error We test the use case when unit is unknown
       formatUnit('fr', 123, { unit: 'unknown' }),
-    ).toMatchSnapshot()
+    ).toMatchSnapshot('unknown unit')
   })
 
   it.each(tests)('%s %o', (_, options, locale, amount) => {


### PR DESCRIPTION
Closes #3778

The `vitest/prefer-snapshot-hint` rule was already removed from the `oxlint.config.ts` overrides block in PR #3701, and the rule is enforced as `['error', 'multi']` in the shared vitest plugin config. The codebase had zero violations under the `multi` mode.

This PR adds descriptive snapshot hints to all remaining `toMatchSnapshot()` calls that lacked them (non-`it.each` calls), improving snapshot debuggability and aligning with the spirit of the rule.

**Changes:**
- `formatDate.test.ts`: added hint to the `invalid date` snapshot
- `formatUnit.test.ts`: added hint to the `unknown unit` snapshot
- `generate-changeset.test.ts`: added hints to 5 `mockedWriteFile` snapshots

Part of [Oxlint v1](https://github.com/scaleway/scaleway-lib/milestone/2).