### PR TITLE
fix(oxlint): fix eslint/init-declarations violations

### DIFF
--- a/.changeset/oxlint-init-declarations.md
+++ b/.changeset/oxlint-init-declarations.md
@@ -1,0 +1,8 @@
+---
+"@scaleway/auth-scw": patch
+"@scaleway/use-analytics": patch
+"@scaleway/use-clipboard": patch
+"@scaleway/use-dataloader": patch
+---
+
+fix oxlint eslint/init-declarations violations

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
     },
   ],
   rules: {
-    'eslint/init-declarations': 'warn',
     'eslint/max-depth': 'warn',
     'eslint/max-params': 'warn',
     'eslint/no-await-in-loop': 'warn',

--- a/packages/auth-scw/src/useAuthScw/helpers.ts
+++ b/packages/auth-scw/src/useAuthScw/helpers.ts
@@ -3,7 +3,7 @@ import type { EncodedJWT, RefreshSessionType } from '../types'
 import { AuthStoreManager } from './authStoreManager'
 import { clientSingleton } from './createClient'
 
-let refreshSessionPromise: Promise<EncodedJWT | undefined> | undefined
+let refreshSessionPromise: Promise<EncodedJWT | undefined> | undefined = undefined
 
 export const refreshSession = ({ paramsRenewRequest, setJWT, onError }: RefreshSessionType) => {
   if (refreshSessionPromise !== undefined) {

--- a/packages/scouter/src/__tests__/BrowserRouter.test.tsx
+++ b/packages/scouter/src/__tests__/BrowserRouter.test.tsx
@@ -43,8 +43,8 @@ describe('component BrowserRouter', () => {
   it('history is re-created for each BrowserRouter', () => {
     expect.hasAssertions()
 
-    let firstHistory: any
-    let secondHistory: any
+    let firstHistory: any = undefined
+    let secondHistory: any = undefined
 
     const TestComponent = () => {
       const history = useHistory()
@@ -74,7 +74,7 @@ describe('component BrowserRouter', () => {
   it('provides root route context', () => {
     expect.hasAssertions()
 
-    let match: Match
+    let match: Match | undefined = undefined
 
     render(
       <BrowserRouter>
@@ -94,7 +94,7 @@ describe('component BrowserRouter', () => {
   it('uses current browser location', () => {
     expect.hasAssertions()
 
-    let location: Location
+    let location: Location | undefined = undefined
 
     render(
       <BrowserRouter>

--- a/packages/scouter/src/__tests__/MemoryRouter.test.tsx
+++ b/packages/scouter/src/__tests__/MemoryRouter.test.tsx
@@ -18,7 +18,7 @@ test('renders children', () => {
 
 test('creates history with initialEntries', () => {
   const initialEntries = ['/initial-path']
-  let location: Location
+  let location: Location | undefined = undefined
 
   render(
     <MemoryRouter initialEntries={initialEntries}>
@@ -38,7 +38,7 @@ test('creates history with initialEntries', () => {
 test('creates history with initialIndex', () => {
   const initialEntries = ['/first', '/second', '/third']
   const initialIndex = 1
-  let location: Location
+  let location: Location | undefined = undefined
 
   render(
     <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
@@ -56,7 +56,7 @@ test('creates history with initialIndex', () => {
 })
 
 test('provides default initialEntries when not specified', () => {
-  let location: Location
+  let location: Location | undefined = undefined
 
   render(
     <MemoryRouter>
@@ -74,8 +74,8 @@ test('provides default initialEntries when not specified', () => {
 })
 
 test('history is stable across re-renders', () => {
-  let firstHistory: History
-  let secondHistory: History
+  let firstHistory: History | undefined = undefined
+  let secondHistory: History | undefined = undefined
 
   const TestComponent = () => {
     const history = useHistory()
@@ -103,7 +103,7 @@ test('history is stable across re-renders', () => {
 })
 
 test('provides root route context', () => {
-  let match: Match
+  let match: Match | undefined = undefined
 
   render(
     <MemoryRouter>

--- a/packages/scouter/src/__tests__/Redirect.test.tsx
+++ b/packages/scouter/src/__tests__/Redirect.test.tsx
@@ -49,7 +49,7 @@ describe('that always renders', () => {
 describe('inside a <Switch>', () => {
   // RRv5 allow this but we don't
   it('does not automatically interpolates params', () => {
-    let params: any
+    let params: any = undefined
 
     render(
       <MemoryRouter initialEntries={['/users/mjackson/messages/123']}>

--- a/packages/scouter/src/__tests__/Route-context.test.tsx
+++ b/packages/scouter/src/__tests__/Route-context.test.tsx
@@ -5,7 +5,7 @@ import type { Location, Match } from '../index'
 import { MemoryRouter, Route } from '../index'
 
 test('provides match to render prop', () => {
-  let match: Match
+  let match: Match | undefined = undefined
 
   render(
     <MemoryRouter initialEntries={['/test']}>
@@ -25,7 +25,7 @@ test('provides match to render prop', () => {
 })
 
 test('provides location to render prop', () => {
-  let location: Location
+  let location: Location | undefined = undefined
 
   render(
     <MemoryRouter initialEntries={['/test?foo=bar']}>
@@ -45,8 +45,8 @@ test('provides location to render prop', () => {
 })
 
 test('match has isExact flag', () => {
-  let exactMatch: Match
-  let looseMatch: Match
+  let exactMatch: Match | undefined = undefined
+  let looseMatch: Match | undefined = undefined
 
   render(
     <MemoryRouter initialEntries={['/test/extra']}>
@@ -74,7 +74,7 @@ test('match has isExact flag', () => {
 })
 
 test('match params are decoded', () => {
-  let match: Match
+  let match: Match | undefined = undefined
 
   render(
     <MemoryRouter initialEntries={['/test/hello%20world']}>

--- a/packages/scouter/src/__tests__/Route.test.tsx
+++ b/packages/scouter/src/__tests__/Route.test.tsx
@@ -257,7 +257,7 @@ describe('the `render` prop', () => {
   it('receives { match, location } props', () => {
     const history = createHistory()
 
-    let props: RouteRenderProps
+    let props: RouteRenderProps | undefined = undefined
     render(
       <Router history={history}>
         <Route

--- a/packages/scouter/src/__tests__/Router.test.tsx
+++ b/packages/scouter/src/__tests__/Router.test.tsx
@@ -21,7 +21,7 @@ test('renders children', () => {
 })
 
 test('provides history to children', () => {
-  let history: any
+  let history: any = undefined
 
   const customHistory = createHistory()
 
@@ -40,7 +40,7 @@ test('provides history to children', () => {
 })
 
 test('provides location to children', () => {
-  let location: Location
+  let location: Location | undefined = undefined
 
   const history = createHistory({
     initialEntries: ['/test-location'],
@@ -61,7 +61,7 @@ test('provides location to children', () => {
 })
 
 test('updates when history changes', () => {
-  let location: Location
+  let location: Location | undefined = undefined
 
   const history = createHistory({
     initialEntries: ['/initial'],
@@ -88,7 +88,7 @@ test('updates when history changes', () => {
 })
 
 test('provides match to children', () => {
-  let match: Match
+  let match: Match | undefined = undefined
 
   const history = createHistory()
 

--- a/packages/scouter/src/__tests__/useNavigate.test.tsx
+++ b/packages/scouter/src/__tests__/useNavigate.test.tsx
@@ -17,7 +17,7 @@ describe(useNavigate, () => {
   })
 
   it('navigate with string path', () => {
-    let location: Location
+    let location: Location | undefined = undefined
 
     const { result } = renderHook(
       () => {
@@ -46,7 +46,7 @@ describe(useNavigate, () => {
   })
 
   it('navigate with object', () => {
-    let location: Location
+    let location: Location | undefined = undefined
 
     const { result } = renderHook(
       () => {
@@ -101,7 +101,7 @@ describe(useNavigate, () => {
   })
 
   it('navigate with state', () => {
-    let location: Location
+    let location: Location | undefined = undefined
 
     const { result } = renderHook(
       () => {
@@ -130,7 +130,7 @@ describe(useNavigate, () => {
   })
 
   it('navigate with hash', () => {
-    let location: Location
+    let location: Location | undefined = undefined
 
     const { result } = renderHook(
       () => {
@@ -159,7 +159,7 @@ describe(useNavigate, () => {
   })
 
   it('navigate with replace=true uses history.replace', () => {
-    let location: Location
+    let location: Location | undefined = undefined
 
     const { result } = renderHook(
       () => {
@@ -188,7 +188,7 @@ describe(useNavigate, () => {
   })
 
   it('navigate with replace=false uses history.push', () => {
-    let location: Location
+    let location: Location | undefined = undefined
 
     const { result } = renderHook(
       () => {
@@ -217,7 +217,7 @@ describe(useNavigate, () => {
   })
 
   it('navigate with state option', () => {
-    let location: Location
+    let location: Location | undefined = undefined
 
     const { result } = renderHook(
       () => {
@@ -246,7 +246,7 @@ describe(useNavigate, () => {
   })
 
   it('navigate with replace and state', () => {
-    let location: Location
+    let location: Location | undefined = undefined
 
     const { result } = renderHook(
       () => {

--- a/packages/use-analytics/src/analytics/useAnalytics.tsx
+++ b/packages/use-analytics/src/analytics/useAnalytics.tsx
@@ -85,7 +85,7 @@ export const AnalyticsProvider = <T extends Events>({
 
   // This effect will unlock the case where we have a failure with the load of the analytics.load as rudderstack doesn't provider any solution for this case.
   useEffect(() => {
-    let timer: ReturnType<typeof setTimeout> | undefined
+    let timer: ReturnType<typeof setTimeout> | undefined = undefined
     if (!isAnalyticsReady && (Number.isFinite(timeout) || shouldRenderOnlyWhenReady)) {
       timer = setTimeout(() => {
         setIsAnalyticsReady(true)

--- a/packages/use-clipboard/src/index.ts
+++ b/packages/use-clipboard/src/index.ts
@@ -34,7 +34,7 @@ export function useClipboard(text: string, options?: IOptions): [boolean, () => 
   }, [text, options])
 
   useEffect(() => {
-    let id: number | undefined
+    let id: number | undefined = undefined
     if (isCopied && successDuration) {
       id = setTimeout(() => {
         setIsCopied(false)

--- a/packages/use-dataloader/src/useDataLoader.ts
+++ b/packages/use-dataloader/src/useDataLoader.ts
@@ -141,7 +141,7 @@ export const useDataLoader = <ResultType = unknown, ErrorType = Error>(
   }, [needLoad, request])
 
   useEffect(() => {
-    let interval: ReturnType<typeof setInterval>
+    let interval: ReturnType<typeof setInterval> | undefined = undefined
 
     if (pollingInterval) {
       interval = setInterval(() => {

--- a/packages/use-growthbook/src/__tests__/AbTestProvider.test.tsx
+++ b/packages/use-growthbook/src/__tests__/AbTestProvider.test.tsx
@@ -135,7 +135,7 @@ describe('abTestProvider', () => {
   })
 
   it('should update attributes when they change', async () => {
-    let rerenderFn: ((element: React.ReactElement) => void) | undefined
+    let rerenderFn: ((element: React.ReactElement) => void) | undefined = undefined
 
     await act(async () => {
       const result = render(
@@ -203,7 +203,7 @@ describe('abTestProvider', () => {
       enableDevMode: true,
     }
 
-    let rerenderFn: ((element: React.ReactElement) => void) | undefined
+    let rerenderFn: ((element: React.ReactElement) => void) | undefined = undefined
 
     await act(async () => {
       const result = render(


### PR DESCRIPTION
Closes #3704

Fixed all violations of `eslint/init-declarations` and removed the rule from `oxlint.config.ts`.

Part of [Oxlint v1](https://github.com/scaleway/scaleway-lib/milestone/2).